### PR TITLE
Get Locations API working in govuk-docker - add configuration

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -52,6 +52,10 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
+  config.hosts += [
+    "locations-api.dev.gov.uk",
+  ]
+
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
 end


### PR DESCRIPTION
What
Add "locations-api.dev.gov.uk" host to enable application running in govuk-docker.

Why
This will allow us to develop the application locally and test the use of it's API (when implemented) in other GOV.UK applications.

[Trello card](https://trello.com/c/KZrHQ6gT/2691-get-locations-api-working-in-govuk-docker-3)
