### PR TITLE
Create inbound api methods

### DIFF
--- a/app/controllers/v1/locations_controller.rb
+++ b/app/controllers/v1/locations_controller.rb
@@ -1,0 +1,9 @@
+module V1
+  class LocationsController < ApplicationController
+    def index
+      token_manager = OsPlacesApi::AccessTokenManager.new
+      locations = OsPlacesApi::Client.new(token_manager).locations_for_postcode(params[:postcode])
+      render json: locations
+    end
+  end
+end

--- a/app/controllers/v1/locations_controller.rb
+++ b/app/controllers/v1/locations_controller.rb
@@ -1,9 +1,21 @@
 module V1
   class LocationsController < ApplicationController
+    before_action :validate_postcode
+
     def index
       token_manager = OsPlacesApi::AccessTokenManager.new
       locations = OsPlacesApi::Client.new(token_manager).locations_for_postcode(params[:postcode])
       render json: locations
+    end
+
+  private
+
+    def validate_postcode
+      @req = PostcodeChecker.new(postcode: params[:postcode])
+
+      unless @req.valid?(params[:postcode])
+        render json: { errors: @req.errors }, status: 400
+      end
     end
   end
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -1,0 +1,5 @@
+class Location
+  include ActiveModel::Model
+
+  attr_accessor :postcode, :address, :latitude, :longitude, :local_custodian_code
+end

--- a/app/models/postcode_checker.rb
+++ b/app/models/postcode_checker.rb
@@ -1,0 +1,7 @@
+class PostcodeChecker
+  include ActiveModel::Model
+
+  attr_accessor :postcode
+
+  validates :postcode, postcode: true
+end

--- a/app/validators/postcode_validator.rb
+++ b/app/validators/postcode_validator.rb
@@ -3,9 +3,9 @@ class PostcodeValidator < ActiveModel::Validator
   INVALID_POSTCODE = /^(BF|BX|GIR|XX|GY|JE|IM|AI|GX|KY|VG)/i.freeze
 
   def validate(record)
-    postcode = record.postcode.gsub(/[`~,.<>;':"\/\[\]|{}()=_+-]| /, "")
+    postcode = record.postcode.to_s.gsub(/[`~,.<>;':"\/\[\]|{}()=_+-]| /, "")
     return if postcode.match?(VALID_POSTCODE) && !postcode.match?(INVALID_POSTCODE)
 
-    record.errors.add :base, "This postcode is invalid"
+    record.errors.add :postcode, "This postcode is invalid"
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
   get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
   get "/healthcheck/ready", to: GovukHealthcheck.rack_response
+
+  namespace :v1 do
+    get "/locations", to: "locations#index"
+  end
 end

--- a/lib/os_places_api/client.rb
+++ b/lib/os_places_api/client.rb
@@ -18,10 +18,12 @@ module OsPlacesApi
       validate_response_code(response)
 
       begin
-        json = JSON.parse(response)
+        json = JSON.parse(response.body)
         raise UnexpectedResponse if json["results"].nil?
 
-        json["results"]
+        json["results"].map do |result|
+          LocationBuilder.new(result).build_location
+        end
       rescue JSON::ParserError
         raise UnexpectedResponse
       end

--- a/lib/os_places_api/location_builder.rb
+++ b/lib/os_places_api/location_builder.rb
@@ -1,0 +1,15 @@
+module OsPlacesApi
+  class LocationBuilder
+    def initialize(result)
+      @result = result
+    end
+
+    def build_location
+      Location.new(postcode: @result.dig("DPA", "POSTCODE"),
+                   address: @result.dig("DPA", "ADDRESS"),
+                   latitude: @result.dig("DPA", "LAT"),
+                   longitude: @result.dig("DPA", "LNG"),
+                   local_custodian_code: @result.dig("DPA", "LOCAL_CUSTODIAN_CODE"))
+    end
+  end
+end

--- a/spec/lib/os_places_api/client_spec.rb
+++ b/spec/lib/os_places_api/client_spec.rb
@@ -10,6 +10,13 @@ RSpec.describe OsPlacesApi::Client do
     let(:api_endpoint) { "https://api.os.uk/search/places/v1/postcode?postcode=#{postcode}&output_srs=WGS84" }
 
     it "should return results for the provided postcode" do
+      locations = [
+        Location.new(address: "1, WHITECHAPEL HIGH STREET, LONDON, E1 8QS",
+                     latitude: 51.5144547,
+                     local_custodian_code: 5900,
+                     longitude: -0.0729933,
+                     postcode: "E1 8QS"),
+      ]
       results = [
         {
           "DPA" => {
@@ -63,7 +70,7 @@ RSpec.describe OsPlacesApi::Client do
       }
       stub_request(:get, api_endpoint).to_return(status: 200, body: api_response.to_json)
 
-      expect(client.locations_for_postcode(postcode)).to eq(results)
+      expect(client.locations_for_postcode(postcode).as_json).to eq(locations.as_json)
     end
 
     it "raises an exception if an invalid postcode is supplied" do

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+
+RSpec.describe Location, type: :model do
+  subject do
+    described_class.new(postcode: "E1 8QS",
+                        address: "1, WHITECHAPEL HIGH STREET, LONDON, E1 8QS",
+                        latitude: 51.5144547,
+                        longitude: -0.0729933,
+                        local_custodian_code: 5900)
+  end
+  describe "Validation" do
+    it "is valid with all attributes present" do
+      expect(subject).to be_valid
+    end
+
+    it "is valid with just some of the attributes" do
+      subject.latitude = nil
+      subject.longitude = nil
+
+      expect(subject).to be_valid
+    end
+
+    it "is valid without any attributes" do
+      subject.postcode = nil
+      subject.address = nil
+      subject.latitude =  nil
+      subject.longitude = nil
+      subject.local_custodian_code = nil
+
+      expect(subject).to be_valid
+    end
+  end
+end

--- a/spec/requests/v1/locations_spec.rb
+++ b/spec/requests/v1/locations_spec.rb
@@ -1,0 +1,47 @@
+require "spec_helper"
+
+RSpec.describe "Locations V1 API" do
+  let(:location1) do
+    Location.new(postcode: "E1 8QS",
+                 address: "1, WHITECHAPEL HIGH STREET, LONDON, E1 8QS",
+                 latitude: 51.5144547,
+                 longitude: -0.0729933,
+                 local_custodian_code: 5900)
+  end
+  let(:location2) do
+    Location.new(postcode: "E1 8QS",
+                 address: "2, WHITECHAPEL HIGH STREET, LONDON, E1 8QS",
+                 latitude: 51.5144548,
+                 longitude: -0.0729934,
+                 local_custodian_code: 5900)
+  end
+
+  let(:postcode) do
+    "E1 8QS"
+  end
+
+  let(:locations) do
+    [location1, location2]
+  end
+
+  let(:token_manager) { double("token_manager") }
+  let(:client) { double("client") }
+
+  before do
+    ENV["OS_PLACES_API_KEY"] = "some_key"
+    ENV["OS_PLACES_API_SECRET"] = "some_secret"
+  end
+
+  context "Successful call" do
+    before do
+      allow(OsPlacesApi::Client).to receive(:new).and_return(client)
+      expect(client).to receive(:locations_for_postcode).with(postcode).and_return(locations)
+    end
+
+    it "Should return proper body" do
+      get "/v1/locations?postcode=#{postcode}"
+
+      expect(response.body).to eq locations.to_json
+    end
+  end
+end

--- a/spec/requests/v1/locations_spec.rb
+++ b/spec/requests/v1/locations_spec.rb
@@ -44,4 +44,27 @@ RSpec.describe "Locations V1 API" do
       expect(response.body).to eq locations.to_json
     end
   end
+
+  context "Client request validation" do
+    let(:expected_validation_response) do
+      { errors: { postcode: ["This postcode is invalid"] } }.to_json
+    end
+
+    context "Postcode is incorrect" do
+      let(:postcode) { "AAA 1AA" }
+      it "Should return error when postcode is incorrect" do
+        get "/v1/locations?postcode=#{postcode}"
+
+        expect(response.body).to eq expected_validation_response
+      end
+    end
+
+    context "Postcode is not provided" do
+      it "Should return error when postcode is not provided" do
+        get "/v1/locations"
+
+        expect(response.body).to eq expected_validation_response
+      end
+    end
+  end
 end

--- a/spec/validators/postcode_validator_spec.rb
+++ b/spec/validators/postcode_validator_spec.rb
@@ -85,6 +85,7 @@ RSpec.describe PostcodeValidator do
       "TKCA 1ZZ",
       "VG1110",
       "VG 1ZZ",
+      nil,
     ]
   end
 


### PR DESCRIPTION
Fronted applications will now be able to make a request `/v1/locations?postcode=#{postcode}` to Locations API and receive collection of locations.
Location model was introduced with following fields:
Address
Latitude
Longitude
Local Custodian Code

We are using previously implemented validation.
[Trello card](https://trello.com/c/62saX1fB/2759-create-inbound-api-methods-5)