### PR TITLE
Use Postgres 13 on Continuous Integration server

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,5 +3,8 @@
 library("govuk")
 
 node {
+  // Run against the Postgres 13 Docker instance on GOV.UK CI
+  govuk.setEnvar("TEST_DATABASE_URL", "postgresql://postgres@127.0.0.1:54313/locations-api-test")
+
   govuk.buildProject()
 }


### PR DESCRIPTION
This changes the Jenkins CI configuration to use Postgres 13.

Postgres 13 is [available at port `54313`][1] on the CI server. By explicitly setting the `TEST_DATABASE_URL`, we're telling Rails to use that Postgres server.

Previously, Rails implicitly used the default Postgres port 5432 which is a Postgres 9.6 server.

https://trello.com/c/IQPrLHtP/2809-upgrade-postgres-in-locations-api-3

[1]: https://docs.publishing.service.gov.uk/manual/test-and-build-a-project-on-jenkins-ci.html#specifying-which-database-to-use