### PR TITLE
Save OS Places API responses to database & serve from DB by default

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -2,4 +2,12 @@ class Location
   include ActiveModel::Model
 
   attr_accessor :postcode, :address, :latitude, :longitude, :local_custodian_code
+
+  def ==(other)
+    postcode == other.postcode &&
+      address == other.address &&
+      latitude == other.latitude &&
+      longitude == other.longitude &&
+      local_custodian_code == other.local_custodian_code
+  end
 end

--- a/app/models/postcode.rb
+++ b/app/models/postcode.rb
@@ -1,0 +1,11 @@
+class Postcode < ApplicationRecord
+  validates_with PostcodeValidator
+  validates :postcode, uniqueness: true
+  before_validation :normalize_postcode
+
+private
+
+  def normalize_postcode
+    self["postcode"] = self["postcode"].to_s.gsub(PostcodeValidator::DISALLOWED_CHARS, "").upcase
+  end
+end

--- a/app/validators/postcode_validator.rb
+++ b/app/validators/postcode_validator.rb
@@ -1,9 +1,10 @@
 class PostcodeValidator < ActiveModel::Validator
   VALID_POSTCODE = /^([A-Z]{1,2}[0-9][A-Z0-9]? ?[0-9][A-Z]{2})$/i.freeze
   INVALID_POSTCODE = /^(BF|BX|GIR|XX|GY|JE|IM|AI|GX|KY|VG)/i.freeze
+  DISALLOWED_CHARS = /[`~,.<>;':"\/\[\]|{}()=_+-]|\s/.freeze
 
   def validate(record)
-    postcode = record.postcode.to_s.gsub(/[`~,.<>;':"\/\[\]|{}()=_+-]| /, "")
+    postcode = record.postcode.to_s.gsub(DISALLOWED_CHARS, "")
     return if postcode.match?(VALID_POSTCODE) && !postcode.match?(INVALID_POSTCODE)
 
     record.errors.add :postcode, "This postcode is invalid"

--- a/db/migrate/20220113154245_create_postcodes.rb
+++ b/db/migrate/20220113154245_create_postcodes.rb
@@ -1,0 +1,11 @@
+class CreatePostcodes < ActiveRecord::Migration[6.1]
+  def change
+    create_table :postcodes do |t|
+      t.string :postcode
+      t.json :results
+
+      t.timestamps
+    end
+    add_index :postcodes, :postcode, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2022_01_13_154245) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "postcodes", force: :cascade do |t|
+    t.string "postcode"
+    t.json "results"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["postcode"], name: "index_postcodes_on_postcode", unique: true
+  end
 
 end

--- a/lib/os_places_api/client.rb
+++ b/lib/os_places_api/client.rb
@@ -25,6 +25,7 @@ module OsPlacesApi
         json = JSON.parse(response.body)
         raise UnexpectedResponse if json["results"].nil?
 
+        Postcode.create!(postcode: postcode, results: json["results"])
         build_locations(json["results"])
       rescue JSON::ParserError
         raise UnexpectedResponse

--- a/lib/os_places_api/client.rb
+++ b/lib/os_places_api/client.rb
@@ -7,6 +7,10 @@ module OsPlacesApi
     end
 
     def locations_for_postcode(postcode)
+      if (record = Postcode.find_by(postcode: postcode))
+        return build_locations(record["results"])
+      end
+
       response = HTTParty.get(
         "https://api.os.uk/search/places/v1/postcode",
         {
@@ -21,9 +25,7 @@ module OsPlacesApi
         json = JSON.parse(response.body)
         raise UnexpectedResponse if json["results"].nil?
 
-        json["results"].map do |result|
-          LocationBuilder.new(result).build_location
-        end
+        build_locations(json["results"])
       rescue JSON::ParserError
         raise UnexpectedResponse
       end
@@ -40,6 +42,12 @@ module OsPlacesApi
       raise RateLimitExceeded if response.code == 429
       raise InternalServerError if response.code == 500
       raise ServiceUnavailable if response.code == 503
+    end
+
+    def build_locations(results)
+      results.map do |result|
+        LocationBuilder.new(result).build_location
+      end
     end
   end
 end

--- a/lib/os_places_api/client.rb
+++ b/lib/os_places_api/client.rb
@@ -25,7 +25,7 @@ module OsPlacesApi
         json = JSON.parse(response.body)
         raise UnexpectedResponse if json["results"].nil?
 
-        Postcode.create!(postcode: postcode, results: json["results"])
+        Postcode.create!(postcode: postcode, results: json["results"]) unless Postcode.find_by(postcode: postcode)
         build_locations(json["results"])
       rescue JSON::ParserError
         raise UnexpectedResponse

--- a/spec/models/postcode_spec.rb
+++ b/spec/models/postcode_spec.rb
@@ -1,0 +1,56 @@
+require "spec_helper"
+
+RSpec.describe Postcode, type: :model do
+  describe "Normalisation" do
+    it "removes disallowed characters from the provided postcode" do
+      [
+        " ",
+        "_",
+        "-",
+        "+",
+        "(",
+        ")",
+        "/",
+      ].each do |char|
+        record = Postcode.create(postcode: "E1#{char}8QS")
+        expect(record.postcode).to eq("E18QS")
+      end
+    end
+
+    it "converts postcode to uppercase" do
+      record = Postcode.create(postcode: "e18qs")
+      expect(record.postcode).to eq("E18QS")
+    end
+
+    it "doesn't edit the provided JSON" do
+      record = Postcode.create(postcode: "E18 QS", results: '[{"foo":"bar"}]')
+      expect(record.results).to eq('[{"foo":"bar"}]')
+    end
+  end
+
+  describe "Validation" do
+    it "successfully validates and stores valid postcodes" do
+      expect { Postcode.create!(postcode: "E18QS", results: "{}") }.to_not raise_error(ActiveRecord::RecordInvalid)
+    end
+
+    it "raises an error if the postcode is missing" do
+      expect { Postcode.create!(results: "{}") }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+
+    it "prevents the same postcode being stored multiple times" do
+      postcode = "E18 QS"
+      Postcode.create!(postcode: postcode)
+      expect { Postcode.create!(postcode: postcode) }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+
+    it "uses the PostcodeValidator" do
+      # Postcode validation logic is already thoroughly tested in
+      # postcode_validator_spec.rb, so we don't need to replicate that here.
+      # We only want to make sure the Postcode model uses the PostcodeValidator.
+      # There doesn't seem to be a way to test that directly, so this is more of
+      # an integration test where we give it a known invalid postcode and ensure
+      # it raises an error.
+      expect { Postcode.create!(postcode: "1AA 1BB") }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+end

--- a/spec/requests/v1/locations_spec.rb
+++ b/spec/requests/v1/locations_spec.rb
@@ -1,39 +1,30 @@
 require "spec_helper"
 
 RSpec.describe "Locations V1 API" do
-  let(:location1) do
-    Location.new(postcode: "E1 8QS",
-                 address: "1, WHITECHAPEL HIGH STREET, LONDON, E1 8QS",
-                 latitude: 51.5144547,
-                 longitude: -0.0729933,
-                 local_custodian_code: 5900)
-  end
-  let(:location2) do
-    Location.new(postcode: "E1 8QS",
-                 address: "2, WHITECHAPEL HIGH STREET, LONDON, E1 8QS",
-                 latitude: 51.5144548,
-                 longitude: -0.0729934,
-                 local_custodian_code: 5900)
-  end
-
-  let(:postcode) do
-    "E1 8QS"
-  end
-
-  let(:locations) do
-    [location1, location2]
-  end
-
-  let(:token_manager) { double("token_manager") }
-  let(:client) { double("client") }
-
   before do
     ENV["OS_PLACES_API_KEY"] = "some_key"
     ENV["OS_PLACES_API_SECRET"] = "some_secret"
   end
 
   context "Successful call" do
+    let(:postcode) { "E1 8QS" }
+    let(:locations) do
+      [
+        Location.new(postcode: "E1 8QS",
+                     address: "1, WHITECHAPEL HIGH STREET, LONDON, E1 8QS",
+                     latitude: 51.5144547,
+                     longitude: -0.0729933,
+                     local_custodian_code: 5900),
+        Location.new(postcode: "E1 8QS",
+                     address: "2, WHITECHAPEL HIGH STREET, LONDON, E1 8QS",
+                     latitude: 51.5144548,
+                     longitude: -0.0729934,
+                     local_custodian_code: 5900),
+      ]
+    end
+
     before do
+      client = double("client")
       allow(OsPlacesApi::Client).to receive(:new).and_return(client)
       expect(client).to receive(:locations_for_postcode).with(postcode).and_return(locations)
     end


### PR DESCRIPTION
Adds model to be saved to the database, acting as a caching layer between Locations API and OS Places API.

Trello: https://trello.com/c/olgAVxu0/2778-implement-caching-database-for-locations-api-5