### PR TITLE
Return average coordinates in Locations API response

### DIFF
--- a/lib/os_places_api/client.rb
+++ b/lib/os_places_api/client.rb
@@ -46,9 +46,15 @@ module OsPlacesApi
     end
 
     def build_locations(results)
-      results.map do |result|
+      locations = results.map do |result|
         LocationBuilder.new(result).build_location
       end
+
+      {
+        "average_latitude" => locations.sum(&:latitude) / locations.size.to_f,
+        "average_longitude" => locations.sum(&:longitude) / locations.size.to_f,
+        "results" => locations,
+      }
     end
   end
 end

--- a/spec/lib/os_places_api/client_spec.rb
+++ b/spec/lib/os_places_api/client_spec.rb
@@ -69,6 +69,8 @@ RSpec.describe OsPlacesApi::Client do
                    longitude: -0.0729933,
                    postcode: "E1 8QS")
     end
+    let(:average_latitude) { 51.5144547 }
+    let(:average_longitude) { -0.0729933 }
 
     context "the postcode doesn't exist in the database" do
       before :each do
@@ -79,7 +81,13 @@ RSpec.describe OsPlacesApi::Client do
         stub_request(:get, api_endpoint)
           .to_return(status: 200, body: successful_response.to_json)
 
-        expect(client.locations_for_postcode(postcode).as_json).to eq([location].as_json)
+        expect(client.locations_for_postcode(postcode).as_json).to eq(
+          {
+            "average_latitude" => average_latitude,
+            "average_longitude" => average_longitude,
+            "results" => [location].as_json,
+          },
+        )
       end
 
       it "should cache the response from a successful request" do
@@ -164,7 +172,13 @@ RSpec.describe OsPlacesApi::Client do
       it "should return the cached data" do
         expect(a_request(:get, api_endpoint)).not_to have_been_made
 
-        expect(client.locations_for_postcode(postcode)).to eq([location])
+        expect(client.locations_for_postcode(postcode)).to eq(
+          {
+            "average_latitude" => average_latitude,
+            "average_longitude" => average_longitude,
+            "results" => [location],
+          },
+        )
       end
     end
 
@@ -177,7 +191,13 @@ RSpec.describe OsPlacesApi::Client do
           .to_return(status: 200, body: successful_response.to_json)
 
         expect(Postcode).not_to receive(:create!)
-        expect(client.locations_for_postcode(postcode)).to eq([location])
+        expect(client.locations_for_postcode(postcode)).to eq(
+          {
+            "average_latitude" => average_latitude,
+            "average_longitude" => average_longitude,
+            "results" => [location],
+          },
+        )
       end
     end
 

--- a/spec/requests/v1/locations_spec.rb
+++ b/spec/requests/v1/locations_spec.rb
@@ -9,18 +9,22 @@ RSpec.describe "Locations V1 API" do
   context "Successful call" do
     let(:postcode) { "E1 8QS" }
     let(:locations) do
-      [
-        Location.new(postcode: "E1 8QS",
-                     address: "1, WHITECHAPEL HIGH STREET, LONDON, E1 8QS",
-                     latitude: 51.5144547,
-                     longitude: -0.0729933,
-                     local_custodian_code: 5900),
-        Location.new(postcode: "E1 8QS",
-                     address: "2, WHITECHAPEL HIGH STREET, LONDON, E1 8QS",
-                     latitude: 51.5144548,
-                     longitude: -0.0729934,
-                     local_custodian_code: 5900),
-      ]
+      {
+        "average_latitude" => 51.51445475,
+        "average_longitude" => -0.07299335,
+        "results" => [
+          Location.new(postcode: "E1 8QS",
+                       address: "1, WHITECHAPEL HIGH STREET, LONDON, E1 8QS",
+                       latitude: 51.5144547,
+                       longitude: -0.0729933,
+                       local_custodian_code: 5900),
+          Location.new(postcode: "E1 8QS",
+                       address: "2, WHITECHAPEL HIGH STREET, LONDON, E1 8QS",
+                       latitude: 51.5144548,
+                       longitude: -0.0729934,
+                       local_custodian_code: 5900),
+        ],
+      }
     end
 
     before do


### PR DESCRIPTION
Modify Locations API to return the average latitude/longitude coordinates for a postcode.

Trello card: https://trello.com/c/N46nNKYN/2867-return-average-lat-long-coordinates-in-locations-api