### PR TITLE
Improve Sidekiq worker resiliency

### DIFF
--- a/app/workers/postcodes_collection_worker.rb
+++ b/app/workers/postcodes_collection_worker.rb
@@ -1,5 +1,6 @@
 class PostcodesCollectionWorker
   include Sidekiq::Worker
+  sidekiq_options queue: :queue_postcode
 
   POSTCODES_PER_SECOND = 3
 

--- a/app/workers/postcodes_collection_worker.rb
+++ b/app/workers/postcodes_collection_worker.rb
@@ -1,23 +1,26 @@
 class PostcodesCollectionWorker
   include Sidekiq::Worker
 
+  POSTCODES_PER_SECOND = 3
+
   def perform(run_continuously = true) # rubocop:disable Style/OptionalBooleanParameter
     ApplicationRecord.with_advisory_lock("ProcessPostcodeWorker-single-worker", timeout_seconds: 0) do
-      loop do
-        refresh_all_postcodes
-        break unless run_continuously
-      end
+      refresh_oldest_postcodes
     end
+    process_next_batch if run_continuously
   end
 
 private
 
-  def refresh_all_postcodes
-    postcodes = Postcode.uncached { Postcode.all.sort_by(&:updated_at).pluck(:postcode) }
-    postcodes.each do |postcode|
-      ProcessPostcodeWorker.perform_async(postcode)
-      sleep 1
+  def refresh_oldest_postcodes
+    postcodes = Postcode.uncached do
+      Postcode.all.sort_by(&:updated_at).pluck(:postcode).first(POSTCODES_PER_SECOND)
     end
-    sleep 10 if postcodes.count.zero?
+    postcodes.each { |postcode| ProcessPostcodeWorker.perform_async(postcode) }
+  end
+
+  def process_next_batch
+    sleep 1
+    PostcodesCollectionWorker.perform_async(true)
   end
 end

--- a/app/workers/process_postcode_worker.rb
+++ b/app/workers/process_postcode_worker.rb
@@ -4,5 +4,7 @@ class ProcessPostcodeWorker
   def perform(postcode)
     token_manager = OsPlacesApi::AccessTokenManager.new
     OsPlacesApi::Client.new(token_manager).locations_for_postcode(postcode, update: true)
+  rescue OsPlacesApi::ClientError => e
+    GovukError.notify(e)
   end
 end

--- a/app/workers/process_postcode_worker.rb
+++ b/app/workers/process_postcode_worker.rb
@@ -1,5 +1,6 @@
 class ProcessPostcodeWorker
   include Sidekiq::Worker
+  sidekiq_options queue: :update_postcode
 
   def perform(postcode)
     token_manager = OsPlacesApi::AccessTokenManager.new

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -5,7 +5,7 @@ Sidekiq.configure_server do |config|
   config.on(:startup) do
     ApplicationRecord.with_advisory_lock("PostcodesCollectionWorker-single-worker", timeout_seconds: 0) do
       Sidekiq::Queue.new("default").clear
-      PostcodesCollectionWorker.new.perform(true)
+      PostcodesCollectionWorker.perform_async(true)
     end
   end
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,5 +1,5 @@
 ---
-:concurrency: 1
+:concurrency: 10
 :logfile: ./log/sidekiq.json.log
 :timeout: 4
 :max_retries: 1

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -4,4 +4,7 @@
 :timeout: 4
 :max_retries: 1
 :queues:
-  - default
+  # See here to understand priorities: https://github.com/mperham/sidekiq/wiki/Advanced-Options#queues
+  # Use powers of 2: higher priority groups are checked twice as often.
+  - [update_postcode, 8]
+  - [queue_postcode, 1]

--- a/lib/os_places_api.rb
+++ b/lib/os_places_api.rb
@@ -1,23 +1,25 @@
 module OsPlacesApi
-  class ExpiredAccessToken < RuntimeError; end
+  class ClientError < RuntimeError; end
 
-  class InvalidOsPlacesApiCredentials < RuntimeError; end
+  class ExpiredAccessToken < ClientError; end
 
-  class InvalidPostcodeProvided < RuntimeError; end
+  class InvalidOsPlacesApiCredentials < ClientError; end
 
-  class InternalServerError < RuntimeError; end
+  class InvalidPostcodeProvided < ClientError; end
 
-  class MethodNotAllowed < RuntimeError; end
+  class InternalServerError < ClientError; end
 
-  class MissingOsPlacesApiCredentials < RuntimeError; end
+  class MethodNotAllowed < ClientError; end
 
-  class RateLimitExceeded < RuntimeError; end
+  class MissingOsPlacesApiCredentials < ClientError; end
 
-  class RequestForbidden < RuntimeError; end
+  class RateLimitExceeded < ClientError; end
 
-  class RequestNotFound < RuntimeError; end
+  class RequestForbidden < ClientError; end
 
-  class ServiceUnavailable < RuntimeError; end
+  class RequestNotFound < ClientError; end
 
-  class UnexpectedResponse < RuntimeError; end
+  class ServiceUnavailable < ClientError; end
+
+  class UnexpectedResponse < ClientError; end
 end

--- a/spec/workers/postcodes_collection_worker_spec.rb
+++ b/spec/workers/postcodes_collection_worker_spec.rb
@@ -1,42 +1,36 @@
 RSpec.describe PostcodesCollectionWorker do
   describe "#perform" do
-    context "where there are no postcodes in the database" do
-      before do
-        allow(Postcode).to receive(:pluck).and_return([])
-      end
-
-      it "sleeps for 10 seconds before trying again" do
-        worker = PostcodesCollectionWorker.new
-        allow(worker).to receive(:sleep)
-        expect(worker).to receive(:sleep).with(10).exactly(1).time
-
-        worker.perform(false)
-      end
+    before do
+      Postcode.destroy_all
+      Postcode.create(postcode: "E18QS", updated_at: 2.days.ago, results: "{}")
+      Postcode.create(postcode: "E18QL", updated_at: 1.day.ago, results: "{}")
+      Postcode.create(postcode: "E18QT", updated_at: Time.now, results: "{}")
     end
 
-    context "where there are postcodes to be refreshed" do
-      before do
-        Postcode.destroy_all
-        Postcode.create(postcode: "E18QS", updated_at: Time.now, results: "{}")
-        Postcode.create(postcode: "E18QL", updated_at: Time.now, results: "{}")
-      end
+    it "creates a ProcessPostcodeWorker for only the oldest postcodes" do
+      stub_const("PostcodesCollectionWorker::POSTCODES_PER_SECOND", 2)
+      expect(ProcessPostcodeWorker).to receive(:perform_async).with("E18QS").ordered
+      expect(ProcessPostcodeWorker).to receive(:perform_async).with("E18QL").ordered
+      expect(ProcessPostcodeWorker).not_to receive(:perform_async).with("E18QT")
 
-      it "creates a worker for each postcode, in descending order of `updated_at`" do
-        expect(ProcessPostcodeWorker).to receive(:perform_async).with("E18QS").ordered
-        expect(ProcessPostcodeWorker).to receive(:perform_async).with("E18QL").ordered
+      PostcodesCollectionWorker.new.perform(false)
+    end
 
-        worker = PostcodesCollectionWorker.new
-        allow(worker).to receive(:sleep)
-        expect(worker).to receive(:sleep).exactly(2).times
+    it "sleeps for 1 second before spawning its replacement" do
+      worker = PostcodesCollectionWorker.new
+      allow(worker).to receive(:sleep) # stop it actually sleeping, for faster tests
+      expect(worker).to receive(:sleep).with(1) # must be '1' for the 'POSTCODES_PER_SECOND' logic to work
 
-        worker.perform(false)
-      end
+      allow(PostcodesCollectionWorker).to receive(:perform_async)
+      expect(PostcodesCollectionWorker).to receive(:perform_async)
 
-      it "cannot be invoked multiple times without the first invocation completing" do
-        allow(ApplicationRecord).to receive(:with_advisory_lock)
-        expect(ApplicationRecord).to receive(:with_advisory_lock)
-        PostcodesCollectionWorker.new.perform(false)
-      end
+      worker.perform(true)
+    end
+
+    it "cannot be invoked multiple times without the first invocation completing" do
+      allow(ApplicationRecord).to receive(:with_advisory_lock)
+      expect(ApplicationRecord).to receive(:with_advisory_lock)
+      PostcodesCollectionWorker.new.perform(false)
     end
   end
 end

--- a/spec/workers/process_postcode_worker_spec.rb
+++ b/spec/workers/process_postcode_worker_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe ProcessPostcodeWorker do
+  describe "#perform" do
+    let(:postcode) { "E18QS" }
+
+    it "updates the given postcode" do
+      stubbed_client = double("OsPlacesApi::Client")
+
+      expect(OsPlacesApi::Client).to receive(:new) { stubbed_client }
+      expect(stubbed_client).to receive(:locations_for_postcode).with(postcode, update: true)
+
+      ProcessPostcodeWorker.new.perform(postcode)
+    end
+
+    it "notifies Sentry when an OS Places API Client exception is raised" do
+      allow(OsPlacesApi::Client).to receive(:new).and_raise(OsPlacesApi::RateLimitExceeded.new)
+
+      expect(GovukError).to receive(:notify).with(OsPlacesApi::RateLimitExceeded)
+
+      ProcessPostcodeWorker.new.perform(postcode)
+    end
+  end
+end


### PR DESCRIPTION
We were seeing the `PostcodesCollectionWorker` die after running for a few hours (possibly related to the nightly datasync).

Rather than have one long-running worker iterate through the entire 1.8 million postcodes in the database, we've now re-architected it to be short-lived, fetching the 3 oldest postcodes and triggering jobs to update those.

This also bumps our postcode updating rate from around 1 per second to around 3 per second, which cuts the total update time from around 21 days to around 7 days. We could in theory go even closer to the OS Places API 10-requests-per-second rate limit, but as Sidekiq is running across multiple instances and this figure is only approximate, it is safer set to the lower value of 3.

Finally, this PR splits the Sidekiq worker queues into two, so that we can allocate more priority to the updating of postcodes.

Trello: https://trello.com/c/jE4Qghdd/2902-fix-sidekiq-workers-locations-api

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
