### PR TITLE
Use sidekiq-uniq-jobs and sidekiq-scheduler for predictability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,8 @@ gem "govuk_app_config"
 gem "govuk_sidekiq"
 gem "httparty"
 gem "pg"
-gem "with_advisory_lock"
+gem "sidekiq-scheduler"
+gem "sidekiq-unique-jobs"
 
 group :development do
   gem "listen"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,9 @@ GEM
     bootsnap (1.7.7)
       msgpack (~> 1.0)
     brakeman (5.2.3)
+    brpoplpush-redis_script (0.1.2)
+      concurrent-ruby (~> 1.0, >= 1.0.5)
+      redis (>= 1.0, <= 5.0)
     builder (3.2.4)
     byebug (11.1.3)
     capybara (3.36.0)
@@ -96,7 +99,12 @@ GEM
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     erubi (1.10.0)
+    et-orbi (1.2.7)
+      tzinfo
     ffi (1.15.3)
+    fugit (1.5.3)
+      et-orbi (~> 1, >= 1.2.7)
+      raabro (~> 1.4)
     gds-api-adapters (79.1.2)
       addressable
       link_header
@@ -190,6 +198,7 @@ GEM
     public_suffix (4.0.7)
     puma (5.6.4)
       nio4r (~> 2.0)
+    raabro (1.4.0)
     racc (1.6.0)
     rack (2.2.3)
     rack-protection (2.2.0)
@@ -284,6 +293,8 @@ GEM
       rubocop (~> 1.19)
     ruby-progressbar (1.11.0)
     rubyzip (2.3.2)
+    rufus-scheduler (3.8.1)
+      fugit (~> 1.1, >= 1.1.6)
     selenium-webdriver (4.1.0)
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
@@ -303,9 +314,19 @@ GEM
       redis (~> 4.5, < 4.6.0)
     sidekiq-logging-json (0.0.19)
       sidekiq (>= 3)
+    sidekiq-scheduler (4.0.0)
+      redis (>= 4.2.0)
+      rufus-scheduler (~> 3.2)
+      sidekiq (>= 4)
+      tilt (>= 1.4.0)
     sidekiq-statsd (2.1.0)
       activesupport
       sidekiq (>= 3.3.1)
+    sidekiq-unique-jobs (7.1.22)
+      brpoplpush-redis_script (> 0.1.1, <= 2.0.0)
+      concurrent-ruby (~> 1.0, >= 1.0.5)
+      sidekiq (>= 5.0, < 8.0)
+      thor (>= 0.20, < 3.0)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -315,6 +336,7 @@ GEM
     statsd-ruby (1.5.0)
     strscan (3.0.2)
     thor (1.2.1)
+    tilt (2.0.10)
     timeout (0.2.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
@@ -333,8 +355,6 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    with_advisory_lock (4.6.0)
-      activerecord (>= 4.2)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.5.4)
@@ -357,9 +377,10 @@ DEPENDENCIES
   rails (= 7.0.3)
   rspec-rails
   rubocop-govuk
+  sidekiq-scheduler
+  sidekiq-unique-jobs
   simplecov
   webmock
-  with_advisory_lock
 
 BUNDLED WITH
    2.2.16

--- a/app/workers/postcodes_collection_worker.rb
+++ b/app/workers/postcodes_collection_worker.rb
@@ -1,27 +1,13 @@
 class PostcodesCollectionWorker
   include Sidekiq::Worker
-  sidekiq_options queue: :queue_postcode
+  sidekiq_options queue: :queue_postcode, lock: :until_executed, lock_timeout: nil
 
   POSTCODES_PER_SECOND = 3
 
-  def perform(run_continuously = true) # rubocop:disable Style/OptionalBooleanParameter
-    ApplicationRecord.with_advisory_lock("ProcessPostcodeWorker-single-worker", timeout_seconds: 0) do
-      refresh_oldest_postcodes
-    end
-    process_next_batch if run_continuously
-  end
-
-private
-
-  def refresh_oldest_postcodes
+  def perform
     postcodes = Postcode.uncached do
       Postcode.all.sort_by(&:updated_at).pluck(:postcode).first(POSTCODES_PER_SECOND)
     end
     postcodes.each { |postcode| ProcessPostcodeWorker.perform_async(postcode) }
-  end
-
-  def process_next_batch
-    sleep 1
-    PostcodesCollectionWorker.perform_async(true)
   end
 end

--- a/app/workers/process_postcode_worker.rb
+++ b/app/workers/process_postcode_worker.rb
@@ -1,6 +1,6 @@
 class ProcessPostcodeWorker
   include Sidekiq::Worker
-  sidekiq_options queue: :update_postcode
+  sidekiq_options queue: :update_postcode, lock: :until_and_while_executing, lock_timeout: nil
 
   def perform(postcode)
     token_manager = OsPlacesApi::AccessTokenManager.new

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -8,3 +8,7 @@
   # Use powers of 2: higher priority groups are checked twice as often.
   - [update_postcode, 8]
   - [queue_postcode, 1]
+:schedule:
+  queue_oldest_postcodes_for_updating:
+    every: '1s'
+    class: PostcodesCollectionWorker

--- a/spec/workers/postcodes_collection_worker_spec.rb
+++ b/spec/workers/postcodes_collection_worker_spec.rb
@@ -13,24 +13,7 @@ RSpec.describe PostcodesCollectionWorker do
       expect(ProcessPostcodeWorker).to receive(:perform_async).with("E18QL").ordered
       expect(ProcessPostcodeWorker).not_to receive(:perform_async).with("E18QT")
 
-      PostcodesCollectionWorker.new.perform(false)
-    end
-
-    it "sleeps for 1 second before spawning its replacement" do
-      worker = PostcodesCollectionWorker.new
-      allow(worker).to receive(:sleep) # stop it actually sleeping, for faster tests
-      expect(worker).to receive(:sleep).with(1) # must be '1' for the 'POSTCODES_PER_SECOND' logic to work
-
-      allow(PostcodesCollectionWorker).to receive(:perform_async)
-      expect(PostcodesCollectionWorker).to receive(:perform_async)
-
-      worker.perform(true)
-    end
-
-    it "cannot be invoked multiple times without the first invocation completing" do
-      allow(ApplicationRecord).to receive(:with_advisory_lock)
-      expect(ApplicationRecord).to receive(:with_advisory_lock)
-      PostcodesCollectionWorker.new.perform(false)
+      PostcodesCollectionWorker.new.perform
     end
   end
 end


### PR DESCRIPTION
sidekiq-uniq-jobs prevents duplicate jobs. This is useful, as
Sidekiq runs on each of the EC2 instances Locations API runs on,
meaning it is difficult to limit instantiation of workers to
predictable levels.

We have therefore removed the 'with_advisory_lock' dependency,
which was the previous attempt at limiting spawned workers to
one. It never seemed to work very well.

Having PostcodesCollectionWorker spawn on upstart, and being
responsible for spawning the next PostcodesCollectionWorker in
the sequence, was brittle. If anything prevented PostcodesCollectionWorker
from spawning the next PostcodesCollectionWorker, the sequence
would simply die.

We now use sidekiq-scheduler to spawn a PostcodesCollectionWorker
every second - which is what we were trying to do by hand before.
This is much less brittle, and much more accurate. Deploying
to Integration, we can see exactly 300 PostcodesCollectionWorker
workers are instantiated over 5 minutes, leading to exactly
900 ProcessPostcodeWorker workers.

NB there is precedent for using sidekiq-scheduler, [in email-alert-api](https://github.com/alphagov/email-alert-api/blob/fb40d5977a2f5840da2a025730499d5564862840/Gemfile#L20-L21).

Trello: https://trello.com/c/jE4Qghdd/2902-fix-sidekiq-workers-locations-api

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
