### PR TITLE
Apply postcode normalisation consistently around Locations API

### DIFF
--- a/app/helpers/postcode_helper.rb
+++ b/app/helpers/postcode_helper.rb
@@ -1,0 +1,7 @@
+module PostcodeHelper
+  DISALLOWED_CHARS = /[`~,.<>;':"\/\[\]|{}()=_+-]|\s/.freeze
+
+  def self.normalise(postcode)
+    postcode.to_s.gsub(DISALLOWED_CHARS, "").upcase
+  end
+end

--- a/app/models/postcode.rb
+++ b/app/models/postcode.rb
@@ -6,6 +6,6 @@ class Postcode < ApplicationRecord
 private
 
   def normalize_postcode
-    self["postcode"] = self["postcode"].to_s.gsub(PostcodeValidator::DISALLOWED_CHARS, "").upcase
+    self["postcode"] = PostcodeHelper.normalise(self["postcode"])
   end
 end

--- a/app/validators/postcode_validator.rb
+++ b/app/validators/postcode_validator.rb
@@ -1,10 +1,9 @@
 class PostcodeValidator < ActiveModel::Validator
   VALID_POSTCODE = /^([A-Z]{1,2}[0-9][A-Z0-9]? ?[0-9][A-Z]{2})$/i.freeze
   INVALID_POSTCODE = /^(BF|BX|GIR|XX|GY|JE|IM|AI|GX|KY|VG)/i.freeze
-  DISALLOWED_CHARS = /[`~,.<>;':"\/\[\]|{}()=_+-]|\s/.freeze
 
   def validate(record)
-    postcode = record.postcode.to_s.gsub(DISALLOWED_CHARS, "")
+    postcode = PostcodeHelper.normalise(record.postcode)
     return if postcode.match?(VALID_POSTCODE) && !postcode.match?(INVALID_POSTCODE)
 
     record.errors.add :postcode, "This postcode is invalid"

--- a/lib/os_places_api/client.rb
+++ b/lib/os_places_api/client.rb
@@ -7,6 +7,8 @@ module OsPlacesApi
     end
 
     def locations_for_postcode(postcode, update: false)
+      postcode = PostcodeHelper.normalise(postcode)
+
       if (record = Postcode.find_by(postcode: postcode)) && !update
         return build_locations(record["results"])
       end


### PR DESCRIPTION
Previously, we were only normalising postcodes at the point of
committing them to the database. We weren't doing any such
normalisation at the OsPlacesApi::Client level, meaning that if
a user passed a postcode that already existed in the database,
but was in a slightly different format (e.g. lowercase, or space
added), OsPlacesApi::Client would treat it as a new postcode and
perform a request.

As well as performing the unnecessary request, the application
would then raise a validation error when attempting to commit the
result to the database, as at this point the postcode would be
normalised and Locations API would realise that the postcode is
not unique, thus PostcodeValidator would raise an exception.

We now normalise the postcode at the point it enters Locations API,
so these kinds of inconsistencies should stop happening.

Fixes #70

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
