### PR TITLE
PostcodesCollectionWorkerMake "select oldest 3 postcode rows" more efficient

### DIFF
--- a/app/workers/postcodes_collection_worker.rb
+++ b/app/workers/postcodes_collection_worker.rb
@@ -6,7 +6,7 @@ class PostcodesCollectionWorker
 
   def perform
     postcodes = Postcode.uncached do
-      Postcode.all.sort_by(&:updated_at).pluck(:postcode).first(POSTCODES_PER_SECOND)
+      Postcode.order("updated_at ASC").first(POSTCODES_PER_SECOND).pluck(:postcode)
     end
     postcodes.each { |postcode| ProcessPostcodeWorker.perform_async(postcode) }
   end


### PR DESCRIPTION
Now that we have over 2 million rows in the database, the old
`sort_by` method was taking a long time to complete - in fact, it
was kicking me out of the Rails console. Using the `.order` method
is far, far quicker.

Also swapping the order of the `.first` and the `.pluck` led to
significant performance improvements too.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
