### PR TITLE
Delete cached postcodes that no longer exist

### DIFF
--- a/app/workers/process_postcode_worker.rb
+++ b/app/workers/process_postcode_worker.rb
@@ -4,7 +4,7 @@ class ProcessPostcodeWorker
 
   def perform(postcode)
     token_manager = OsPlacesApi::AccessTokenManager.new
-    OsPlacesApi::Client.new(token_manager).locations_for_postcode(postcode, update: true)
+    OsPlacesApi::Client.new(token_manager).update_postcode(postcode)
   rescue OsPlacesApi::ClientError => e
     GovukError.notify(e)
   end

--- a/lib/os_places_api/client.rb
+++ b/lib/os_places_api/client.rb
@@ -23,8 +23,11 @@ module OsPlacesApi
       postcode = PostcodeHelper.normalise(postcode)
       response = get_api_response(postcode)
       record = Postcode.find_by(postcode: postcode)
-
-      record.update(results: response["results"])
+      if response["results"].nil?
+        record.destroy
+      else
+        record.update(results: response["results"], updated_at: Time.now)
+      end
     end
 
   private

--- a/lib/os_places_api/client.rb
+++ b/lib/os_places_api/client.rb
@@ -6,36 +6,25 @@ module OsPlacesApi
       @token_manager = token_manager
     end
 
-    def locations_for_postcode(postcode, update: false)
+    def locations_for_postcode(postcode)
       postcode = PostcodeHelper.normalise(postcode)
-
-      if (record = Postcode.find_by(postcode: postcode)) && !update
+      if (record = Postcode.find_by(postcode: postcode))
         return build_locations(record["results"])
       end
 
-      response = HTTParty.get(
-        "https://api.os.uk/search/places/v1/postcode",
-        {
-          query: { postcode: postcode, output_srs: "WGS84" },
-          headers: { "Authorization": "Bearer #{@token_manager.access_token}" },
-        },
-      )
+      response = get_api_response(postcode)
+      raise UnexpectedResponse if response["results"].nil?
 
-      validate_response_code(response)
+      Postcode.create!(postcode: postcode, results: response["results"]) unless Postcode.find_by(postcode: postcode)
+      build_locations(response["results"])
+    end
 
-      begin
-        json = JSON.parse(response.body)
-        raise UnexpectedResponse if json["results"].nil?
+    def update_postcode(postcode)
+      postcode = PostcodeHelper.normalise(postcode)
+      response = get_api_response(postcode)
+      record = Postcode.find_by(postcode: postcode)
 
-        if (existing = Postcode.find_by(postcode: postcode))
-          existing.update(results: json["results"], updated_at: Time.now) if update
-        else
-          Postcode.create!(postcode: postcode, results: json["results"])
-        end
-        build_locations(json["results"])
-      rescue JSON::ParserError
-        raise UnexpectedResponse
-      end
+      record.update(results: response["results"])
     end
 
   private
@@ -61,6 +50,24 @@ module OsPlacesApi
         "average_longitude" => locations.sum(&:longitude) / locations.size.to_f,
         "results" => locations,
       }
+    end
+
+    def get_api_response(postcode)
+      response = HTTParty.get(
+        "https://api.os.uk/search/places/v1/postcode",
+        {
+          query: { postcode: postcode, output_srs: "WGS84" },
+          headers: { "Authorization": "Bearer #{@token_manager.access_token}" },
+        },
+      )
+
+      validate_response_code(response)
+
+      begin
+        JSON.parse(response.body)
+      rescue JSON::ParserError
+        raise UnexpectedResponse
+      end
     end
   end
 end

--- a/spec/lib/os_places_api/client_spec.rb
+++ b/spec/lib/os_places_api/client_spec.rb
@@ -1,67 +1,68 @@
 require "spec_helper"
 
 RSpec.describe OsPlacesApi::Client do
-  describe "#locations_for_postcode" do
-    let(:client) do
-      described_class.new(instance_double("AccessTokenManager", access_token: "some token"))
-    end
-    let(:postcode) { "E18QS" }
-    let(:api_endpoint) { "https://api.os.uk/search/places/v1/postcode?output_srs=WGS84&postcode=#{postcode}" }
-    let(:successful_response) do
+  let(:client) do
+    described_class.new(instance_double("AccessTokenManager", access_token: "some token"))
+  end
+  let(:postcode) { "E18QS" }
+  let(:api_endpoint) { "https://api.os.uk/search/places/v1/postcode?output_srs=WGS84&postcode=#{postcode}" }
+  let(:successful_response) do
+    {
+      "header": {
+        "uri": api_endpoint,
+        "query": "postcode=#{postcode}",
+        "offset": 0,
+        "totalresults": 1, # really 12, but we've omitted the other 11 in `results` above
+        "format": "JSON",
+        "dataset": "DPA",
+        "lr": "EN,CY",
+        "maxresults": 100,
+        "epoch": "87",
+        "output_srs": "WGS84",
+      },
+      "results": os_places_api_results,
+    }
+  end
+  let(:os_places_api_results) do
+    [
       {
-        "header": {
-          "uri": api_endpoint,
-          "query": "postcode=#{postcode}",
-          "offset": 0,
-          "totalresults": 1, # really 12, but we've omitted the other 11 in `results` above
-          "format": "JSON",
-          "dataset": "DPA",
-          "lr": "EN,CY",
-          "maxresults": 100,
-          "epoch": "87",
-          "output_srs": "WGS84",
+        "DPA" => {
+          "UPRN" => "6714279",
+          "UDPRN" => "54673874",
+          "ADDRESS" => "1, WHITECHAPEL HIGH STREET, LONDON, E1 8QS",
+          "BUILDING_NUMBER" => "1",
+          "THOROUGHFARE_NAME" => "WHITECHAPEL HIGH STREET",
+          "POST_TOWN" => "LONDON",
+          "POSTCODE" => "E1 8QS",
+          "RPC" => "2",
+          "X_COORDINATE" => 533_813.0,
+          "Y_COORDINATE" => 181_262.0,
+          "LNG" => -0.0729933,
+          "LAT" => 51.5144547,
+          "STATUS" => "APPROVED",
+          "LOGICAL_STATUS_CODE" => "1",
+          "CLASSIFICATION_CODE" => "CO01",
+          "CLASSIFICATION_CODE_DESCRIPTION" => "Office / Work Studio",
+          "LOCAL_CUSTODIAN_CODE" => 5900,
+          "LOCAL_CUSTODIAN_CODE_DESCRIPTION" => "TOWER HAMLETS",
+          "POSTAL_ADDRESS_CODE" => "D",
+          "POSTAL_ADDRESS_CODE_DESCRIPTION" => "A record which is linked to PAF",
+          "BLPU_STATE_CODE" => "1",
+          "BLPU_STATE_CODE_DESCRIPTION" => "Under construction",
+          "TOPOGRAPHY_LAYER_TOID" => "osgb1000006035651",
+          "LAST_UPDATE_DATE" => "17/06/2017",
+          "ENTRY_DATE" => "17/02/2017",
+          "BLPU_STATE_DATE" => "17/02/2017",
+          "LANGUAGE" => "EN",
+          "MATCH" => 1.0,
+          "MATCH_DESCRIPTION" => "EXACT",
         },
-        "results": os_places_api_results,
-      }
-    end
-    let(:os_places_api_results) do
-      [
-        {
-          "DPA" => {
-            "UPRN" => "6714279",
-            "UDPRN" => "54673874",
-            "ADDRESS" => "1, WHITECHAPEL HIGH STREET, LONDON, E1 8QS",
-            "BUILDING_NUMBER" => "1",
-            "THOROUGHFARE_NAME" => "WHITECHAPEL HIGH STREET",
-            "POST_TOWN" => "LONDON",
-            "POSTCODE" => "E1 8QS",
-            "RPC" => "2",
-            "X_COORDINATE" => 533_813.0,
-            "Y_COORDINATE" => 181_262.0,
-            "LNG" => -0.0729933,
-            "LAT" => 51.5144547,
-            "STATUS" => "APPROVED",
-            "LOGICAL_STATUS_CODE" => "1",
-            "CLASSIFICATION_CODE" => "CO01",
-            "CLASSIFICATION_CODE_DESCRIPTION" => "Office / Work Studio",
-            "LOCAL_CUSTODIAN_CODE" => 5900,
-            "LOCAL_CUSTODIAN_CODE_DESCRIPTION" => "TOWER HAMLETS",
-            "POSTAL_ADDRESS_CODE" => "D",
-            "POSTAL_ADDRESS_CODE_DESCRIPTION" => "A record which is linked to PAF",
-            "BLPU_STATE_CODE" => "1",
-            "BLPU_STATE_CODE_DESCRIPTION" => "Under construction",
-            "TOPOGRAPHY_LAYER_TOID" => "osgb1000006035651",
-            "LAST_UPDATE_DATE" => "17/06/2017",
-            "ENTRY_DATE" => "17/02/2017",
-            "BLPU_STATE_DATE" => "17/02/2017",
-            "LANGUAGE" => "EN",
-            "MATCH" => 1.0,
-            "MATCH_DESCRIPTION" => "EXACT",
-          },
-        },
-        # subsequent results omitted for brevity
-      ]
-    end
+      },
+      # subsequent results omitted for brevity
+    ]
+  end
+
+  describe "#locations_for_postcode" do
     let(:location) do
       Location.new(address: "1, WHITECHAPEL HIGH STREET, LONDON, E1 8QS",
                    latitude: 51.5144547,
@@ -196,44 +197,6 @@ RSpec.describe OsPlacesApi::Client do
       end
     end
 
-    context "the postcode is outdated in the database" do
-      before do
-        old_results = os_places_api_results.first["DPA"].dup
-        old_results["LNG"] = -1
-        old_results["LAT"] = -1
-        Postcode.create(postcode: postcode, results: [{ "DPA" => old_results }])
-      end
-
-      it "should query OS Places API and update cached data when `update: true` is passed" do
-        stub_request(:get, api_endpoint)
-          .to_return(status: 200, body: successful_response.to_json)
-
-        expect(client.locations_for_postcode(postcode, update: true).as_json).to eq(
-          {
-            "average_latitude" => average_latitude,
-            "average_longitude" => average_longitude,
-            "results" => [location].as_json,
-          },
-        )
-      end
-
-      it "should not query OS Places API when `update: false` is passed" do
-        expect(a_request(:get, api_endpoint)).not_to have_been_made
-
-        expected_results = [location].as_json.dup
-        expected_results.first["latitude"] = -1.0
-        expected_results.first["longitude"] = -1.0
-
-        expect(client.locations_for_postcode(postcode, update: false).as_json).to eq(
-          {
-            "average_latitude" => -1.0,
-            "average_longitude" => -1.0,
-            "results" => expected_results,
-          },
-        )
-      end
-    end
-
     context "there are two simultaneous requests for the same (new) postcode" do
       it "should not attempt to create the postcode twice" do
         existing_record = Postcode.create(postcode: postcode, results: os_places_api_results)
@@ -268,6 +231,20 @@ RSpec.describe OsPlacesApi::Client do
 
         expect { client.locations_for_postcode(postcode) }.to raise_error(OsPlacesApi::InvalidPostcodeProvided)
       end
+    end
+  end
+
+  describe "#update_postcode" do
+    it "should query OS Places API and update cached data" do
+      old_results = os_places_api_results.first["DPA"].dup
+      old_results["LNG"] = -1
+      old_results["LAT"] = -1
+      Postcode.create(postcode: postcode, results: [{ "DPA" => old_results }])
+      stub_request(:get, api_endpoint)
+        .to_return(status: 200, body: successful_response.to_json)
+
+      client.update_postcode(postcode)
+      expect(Postcode.where(postcode: postcode).pluck(:results)).to eq([os_places_api_results])
     end
   end
 end

--- a/spec/lib/os_places_api/client_spec.rb
+++ b/spec/lib/os_places_api/client_spec.rb
@@ -246,5 +246,15 @@ RSpec.describe OsPlacesApi::Client do
       client.update_postcode(postcode)
       expect(Postcode.where(postcode: postcode).pluck(:results)).to eq([os_places_api_results])
     end
+
+    it "should query OS Places API and delete the postcode if it was terminated" do
+      Postcode.create(postcode: postcode, results: [{}])
+      stub_request(:get, api_endpoint)
+        .to_return(status: 200, body: {}.to_json)
+
+      expect(Postcode.find_by(postcode: postcode)).not_to eq(nil)
+      client.update_postcode(postcode)
+      expect(Postcode.find_by(postcode: postcode)).to eq(nil)
+    end
   end
 end

--- a/spec/workers/process_postcode_worker_spec.rb
+++ b/spec/workers/process_postcode_worker_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ProcessPostcodeWorker do
       stubbed_client = double("OsPlacesApi::Client")
 
       expect(OsPlacesApi::Client).to receive(:new) { stubbed_client }
-      expect(stubbed_client).to receive(:locations_for_postcode).with(postcode, update: true)
+      expect(stubbed_client).to receive(:update_postcode).with(postcode)
 
       ProcessPostcodeWorker.new.perform(postcode)
     end


### PR DESCRIPTION
While importing postcodes from mapit database into locations-api, we encountered a few that no longer exist. There is no value in keeping these "retired" postcodes.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
Trello card: https://trello.com/c/iy6P2rvX/2875-warm-up-locations-api-cache-5