### PR TITLE
Install `sentry-sidekiq` gem and remove manual call to GovukError

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem "govuk_app_config"
 gem "govuk_sidekiq"
 gem "httparty"
 gem "pg"
+gem "sentry-sidekiq"
 gem "sidekiq-scheduler"
 gem "sidekiq-unique-jobs"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -307,6 +307,9 @@ GEM
       sentry-ruby-core (= 5.3.0)
     sentry-ruby-core (5.3.0)
       concurrent-ruby
+    sentry-sidekiq (5.3.0)
+      sentry-ruby-core (~> 5.3.0)
+      sidekiq (>= 3.0)
     sidekiq (5.2.10)
       connection_pool (~> 2.2, >= 2.2.2)
       rack (~> 2.0)
@@ -377,6 +380,7 @@ DEPENDENCIES
   rails (= 7.0.3)
   rspec-rails
   rubocop-govuk
+  sentry-sidekiq
   sidekiq-scheduler
   sidekiq-unique-jobs
   simplecov

--- a/app/workers/process_postcode_worker.rb
+++ b/app/workers/process_postcode_worker.rb
@@ -5,7 +5,5 @@ class ProcessPostcodeWorker
   def perform(postcode)
     token_manager = OsPlacesApi::AccessTokenManager.new
     OsPlacesApi::Client.new(token_manager).locations_for_postcode(postcode, update: true)
-  rescue OsPlacesApi::ClientError => e
-    GovukError.notify(e)
   end
 end

--- a/spec/workers/process_postcode_worker_spec.rb
+++ b/spec/workers/process_postcode_worker_spec.rb
@@ -10,13 +10,5 @@ RSpec.describe ProcessPostcodeWorker do
 
       ProcessPostcodeWorker.new.perform(postcode)
     end
-
-    it "notifies Sentry when an OS Places API Client exception is raised" do
-      allow(OsPlacesApi::Client).to receive(:new).and_raise(OsPlacesApi::RateLimitExceeded.new)
-
-      expect(GovukError).to receive(:notify).with(OsPlacesApi::RateLimitExceeded)
-
-      ProcessPostcodeWorker.new.perform(postcode)
-    end
   end
 end


### PR DESCRIPTION
In #74, we added a manual call to `GovukError.notify` when an
exception was raised in Sidekiq. This was because Sentry would
not receive any errors from Sidekiq.

However, govuk_app_config does support Sidekiq Sentry error
reporting - it just needs the `sentry-sidekiq` gem adding.
This is explicitly warned about as of version 4.6.0:
https://github.com/alphagov/govuk_app_config/blob/main/CHANGELOG.md#460

By adding this dependency, we should be able to remove the
duplicate config.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
