### PR TITLE
Make 'ProcessPostcodeWorker' more resilient to new postcodes

### DIFF
--- a/lib/os_places_api/client.rb
+++ b/lib/os_places_api/client.rb
@@ -24,9 +24,11 @@ module OsPlacesApi
       response = get_api_response(postcode)
       record = Postcode.find_by(postcode: postcode)
       if response["results"].nil?
-        record.destroy
+        record.destroy unless record.nil?
+      elsif record.nil?
+        Postcode.create!(postcode: postcode, results: response["results"])
       else
-        record.update(results: response["results"], updated_at: Time.now)
+        record.update(results: response["results"])
       end
     end
 

--- a/spec/lib/os_places_api/client_spec.rb
+++ b/spec/lib/os_places_api/client_spec.rb
@@ -235,7 +235,15 @@ RSpec.describe OsPlacesApi::Client do
   end
 
   describe "#update_postcode" do
-    it "should query OS Places API and update cached data" do
+    it "should query OS Places API and add a new row if postcode doesn't exist" do
+      stub_request(:get, api_endpoint)
+        .to_return(status: 200, body: successful_response.to_json)
+
+      client.update_postcode(postcode)
+      expect(Postcode.where(postcode: postcode).pluck(:results)).to eq([os_places_api_results])
+    end
+
+    it "should query OS Places API and update cached data if postcode exists" do
       old_results = os_places_api_results.first["DPA"].dup
       old_results["LNG"] = -1
       old_results["LAT"] = -1


### PR DESCRIPTION
In theory, any postcode that doesn't yet exist would either be:

1) added via the `populate_postcodes_table` rake task, i.e. given
   a placeholder result of `{}` and then updated asynchronously, or
2) added via a call to `OsPlacesApi::Client.locations_for_postcode`

However, if a developer goes into the console and calls
`ProcessPostcodeWorker.perform(postcode)` on a new postcode, it
will raise an exception `NoMethodError (undefined method destroy'
for nil:NilClass)`. We want to have the worker encounter such
scenarios gracefully. We could either have it raise an exception
along the lines of "Tried updating a postcode that hasn't been
added yet", but it is just as easy to create the postcode, which
is clearly what the developer would want in such a case.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
