### PR TITLE
Force `updated_at` to update even if no changes to the DB record

### DIFF
--- a/lib/os_places_api/client.rb
+++ b/lib/os_places_api/client.rb
@@ -28,7 +28,7 @@ module OsPlacesApi
       elsif record.nil?
         Postcode.create!(postcode: postcode, results: response["results"])
       else
-        record.update(results: response["results"])
+        record.update(results: response["results"]) && record.touch
       end
     end
 

--- a/spec/lib/os_places_api/client_spec.rb
+++ b/spec/lib/os_places_api/client_spec.rb
@@ -255,6 +255,16 @@ RSpec.describe OsPlacesApi::Client do
       expect(Postcode.where(postcode: postcode).pluck(:results)).to eq([os_places_api_results])
     end
 
+    it "should update the `updated_at` property even if no changes were made" do
+      updated_at = 1.day.ago
+      Postcode.create(postcode: postcode, results: successful_response[:results], updated_at: updated_at)
+      stub_request(:get, api_endpoint)
+        .to_return(status: 200, body: successful_response.to_json)
+
+      client.update_postcode(postcode)
+      expect(Postcode.find_by(postcode: postcode).updated_at.strftime("%A")).to eq(Time.now.strftime("%A"))
+    end
+
     it "should query OS Places API and delete the postcode if it was terminated" do
       Postcode.create(postcode: postcode, results: [{}])
       stub_request(:get, api_endpoint)


### PR DESCRIPTION
If we have a postcode's results cached in the database, and if
the response from OS Places API is identical the next time we
attempt to update the postcode (which we expect to be the case the
majority of the time), no `UPDATE` SQL query actually gets
executed, as there is nothing to update.

However, this means the `updated_at` property remains unchanged,
and as we use this property to decide which postcode to attempt
to update next ([1]), Locations API gets stuck attempting to
update the same few postcodes on a loop.

In this commit, we change Locations API to update the `updated_at`
field even if there has been no change to the contents of the
record in the database. We can therefore accurately use this
field to figure out when the last attempt was made to 'refresh'
the postcode via OS Places API.

This should fix the bug whereby no postcodes are being updated
anymore because the 3 oldest postcodes' results are unchanged,
and thus the 3 oldest postcodes would continue to be the 'oldest'
postcodes.

[1]: https://github.com/alphagov/locations-api/blob/a0605a6608f5d6d2c8f8de37ffb4d0d7f88dee33/app/workers/postcodes_collection_worker.rb#L9

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
