### PR TITLE
Fix 500 errors and stop logging client errors

### DIFF
--- a/app/controllers/v1/locations_controller.rb
+++ b/app/controllers/v1/locations_controller.rb
@@ -9,6 +9,8 @@ module V1
       begin
         locations = OsPlacesApi::Client.new(token_manager).locations_for_postcode(params[:postcode])
         render json: locations
+      rescue OsPlacesApi::InvalidPostcodeProvided
+        render json: { errors: { "postcode": ["Invalid postcode provided"] } }, status: 400
       rescue OsPlacesApi::NoResultsForPostcode => e
         Sentry.capture_exception(e) # Ensure that this exception is still reported
         render json: { errors: { "postcode": ["No results found for given postcode"] } }, status: 404

--- a/app/controllers/v1/locations_controller.rb
+++ b/app/controllers/v1/locations_controller.rb
@@ -11,8 +11,7 @@ module V1
         render json: locations
       rescue OsPlacesApi::InvalidPostcodeProvided
         render json: { errors: { "postcode": ["Invalid postcode provided"] } }, status: 400
-      rescue OsPlacesApi::NoResultsForPostcode => e
-        Sentry.capture_exception(e) # Ensure that this exception is still reported
+      rescue OsPlacesApi::NoResultsForPostcode
         render json: { errors: { "postcode": ["No results found for given postcode"] } }, status: 404
       end
     end

--- a/spec/requests/v1/locations_spec.rb
+++ b/spec/requests/v1/locations_spec.rb
@@ -74,15 +74,16 @@ RSpec.describe "Locations V1 API" do
       expect(client).to receive(:locations_for_postcode).with(postcode).and_raise(OsPlacesApi::NoResultsForPostcode)
     end
 
-    it "Should return proper body with error message, and report the error to Sentry" do
-      expect(Sentry).to receive(:capture_exception).and_wrap_original do |original, *args|
-        expect(Sentry.get_current_scope.tags).to include(postcode: normalised_postcode)
-        original.call(*args)
-      end
-
+    it "Should return proper body with error message" do
       get "/v1/locations?postcode=#{postcode}"
 
       expect(response.body).to eq expected_validation_response
+    end
+
+    it "Should return 404 to the upstream app" do
+      get "/v1/locations?postcode=#{postcode}"
+
+      expect(response.status).to eq 404
     end
   end
 

--- a/spec/requests/v1/locations_spec.rb
+++ b/spec/requests/v1/locations_spec.rb
@@ -89,6 +89,9 @@ RSpec.describe "Locations V1 API" do
   context "When the postcode passes our validity check but OS Places API says it is invalid" do
     let(:postcode) { "AB12 3CD" }
     let(:normalised_postcode) { "AB123CD" }
+    let(:expected_validation_response) do
+      { errors: { postcode: ["Invalid postcode provided"] } }.to_json
+    end
 
     before do
       client = double("client")
@@ -96,13 +99,16 @@ RSpec.describe "Locations V1 API" do
       expect(client).to receive(:locations_for_postcode).with(postcode).and_raise(OsPlacesApi::InvalidPostcodeProvided)
     end
 
-    it "Should report the error to Sentry, tagged with the postcode" do
-      expect(Sentry).to receive(:capture_exception).and_wrap_original do |original, *args|
-        expect(Sentry.get_current_scope.tags).to include(postcode: normalised_postcode)
-        original.call(*args)
-      end
+    it "Should return proper body with error message" do
+      get "/v1/locations?postcode=#{postcode}"
 
-      expect { get "/v1/locations?postcode=#{postcode}" }.to raise_error(OsPlacesApi::InvalidPostcodeProvided)
+      expect(response.body).to eq expected_validation_response
+    end
+
+    it "Should return 400 to the upstream app" do
+      get "/v1/locations?postcode=#{postcode}"
+
+      expect(response.status).to eq 400
     end
   end
 


### PR DESCRIPTION
See commits for details.

This PR fixes Locations API returning a 500 response for some postcode inputs - it now returns the correct 400 response.

It also stops logging 400 and 404 responses as exceptions in Sentry. These are client errors and are not actionable, so [should not be logged in Sentry](https://docs.publishing.service.gov.uk/manual/sentry.html#deciding-whether-to-log-errors-in-sentry).

Trello: https://trello.com/c/6vdbP8Kz/2986-fix-remove-locations-api-sentry-errors

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
