### PR TITLE
Guard no results after filter

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,7 +1,0 @@
-class ApplicationJob < ActiveJob::Base
-  # Automatically retry jobs that encountered a deadlock
-  # retry_on ActiveRecord::Deadlocked
-
-  # Most jobs are safe to ignore if the underlying records are no longer available
-  # discard_on ActiveJob::DeserializationError
-end

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,4 +1,6 @@
 desc "Run all linters"
 task lint: :environment do
+  # :nocov:
   sh "rubocop"
+  # :nocov:
 end


### PR DESCRIPTION
In certain cases (eg: CH25 9BJ) it's possible to get a postcode with results from OS Places API, but then filter them out before calculating the average location, resulting in locations-api returning an apparent good result for queries but with average latitude/longitude set to nil.

This PR adds in checks at the point locations are built that will throw a NoResultsForPostcode exception (identical to that thrown if there are no results for a valid response), and adds checks when a postcode is to be created or updated in the postcode cache that prevent these filtered locations from being added (keeping them consistent with situations where there are no results for a valid response, as above).

(Also: 2 additional commits to remove an unused file and mark an unimportant part of a linter rake task as not necessary for coverage, getting locations-api to 100% coverage).


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
