### PR TITLE
Make the OS Places rate limit configurable.

### DIFF
--- a/app/workers/postcodes_collection_worker.rb
+++ b/app/workers/postcodes_collection_worker.rb
@@ -2,7 +2,7 @@ class PostcodesCollectionWorker
   include Sidekiq::Worker
   sidekiq_options queue: :queue_postcode, lock: :until_executed, lock_timeout: nil
 
-  POSTCODES_PER_SECOND = 3
+  POSTCODES_PER_SECOND = ENV.fetch("OS_PLACES_API_POSTCODES_PER_SECOND", 3)
 
   def perform
     postcodes = Postcode.uncached do


### PR DESCRIPTION
Instead of hardcoding 3 per second, use the environment variable `OS_PLACES_API_POSTCODES_PER_SECOND` if it's set, otherwise default to 3.

This helps Replatforming to avoid overloading OS Places API while running in parallel with the existing EC2 deployments.