### PR TITLE
ENVs all come in as strings, so we need to #to_i this before use.

### DIFF
--- a/app/workers/postcodes_collection_worker.rb
+++ b/app/workers/postcodes_collection_worker.rb
@@ -2,7 +2,7 @@ class PostcodesCollectionWorker
   include Sidekiq::Worker
   sidekiq_options queue: :queue_postcode, lock: :until_executed, lock_timeout: nil
 
-  POSTCODES_PER_SECOND = ENV.fetch("OS_PLACES_API_POSTCODES_PER_SECOND", 3)
+  POSTCODES_PER_SECOND = ENV.fetch("OS_PLACES_API_POSTCODES_PER_SECOND", 3).to_i
 
   def perform
     postcodes = Postcode.uncached do


### PR DESCRIPTION
Should be safe to allow errors, since this won't be changed often and it  doesn't affect the front end.

https://trello.com/c/Iwbjw2xs/1643-investigate-the-high-volume-error-on-locations-api-happening-every-night

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
