### PR TITLE
Allow Kircaldy postcodes

### DIFF
--- a/app/validators/postcode_validator.rb
+++ b/app/validators/postcode_validator.rb
@@ -1,11 +1,19 @@
 class PostcodeValidator < ActiveModel::Validator
   VALID_POSTCODE = /^([A-Z]{1,2}[0-9][A-Z0-9]? ?[0-9][A-Z]{2})$/i
-  INVALID_POSTCODE = /^(BF|BX|GIR|XX|GY|JE|IM|AI|GX|KY|VG)/i
+  INVALID_POSTCODE = /^(BF|BX|GIR|XX|GY|JE|IM|AI|GX|VG)/i
+  CAYMANS_POSTCODE = /^KY[0-9]-/i
 
   def validate(record)
-    postcode = PostcodeHelper.normalise(record.postcode)
-    return if postcode.match?(VALID_POSTCODE) && !postcode.match?(INVALID_POSTCODE)
+    return if valid_postcode?(record.postcode) && !invalid_postcode?(record.postcode)
 
     record.errors.add :postcode, "This postcode is invalid"
+  end
+
+  def valid_postcode?(postcode)
+    PostcodeHelper.normalise(postcode).match?(VALID_POSTCODE)
+  end
+
+  def invalid_postcode?(postcode)
+    PostcodeHelper.normalise(postcode).match?(INVALID_POSTCODE) || postcode.match?(CAYMANS_POSTCODE)
   end
 end

--- a/spec/validators/postcode_validator_spec.rb
+++ b/spec/validators/postcode_validator_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe PostcodeValidator do
       "B33 8TH",
       "CR2 6XH",
       "DN55 1PT",
+      "KY11 4JU",
     ]
   end
 


### PR DESCRIPTION
KY was incorrectly classified as a non-geographic postcode, in fact KY covers Kircaldy, and it's specifically KYx- postcodes we want to avoid (Caymans Islands postcodes). The postcode normalisation process in the validator makes it impossible to spot these, so we split them out and check against the non-normalised postcode. This has a slight cost of having to call PostcodeHelper.normalise twice in a validation, but it's so lightweight that that shouldn't affect us.

(One of a smorgasboard of different problems covered by: https://trello.com/c/rAL7Q3JC/1687-investigate-and-fix-missing-postcodes-in-locations-api)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
