### PR TITLE
Allow non-filtered results to contribute to average lat/lon

### DIFF
--- a/spec/lib/os_places_api/client_spec.rb
+++ b/spec/lib/os_places_api/client_spec.rb
@@ -211,8 +211,8 @@ RSpec.describe OsPlacesApi::Client do
                      longitude: -0.0729935),
       ]
     end
-    let(:average_latitude) { 51.5144546 }
-    let(:average_longitude) { -0.0729934 }
+    let(:average_latitude) { 51.51446256666667 }
+    let(:average_longitude) { -0.07298533333333333 }
 
     context "the postcode doesn't exist in the database" do
       before :each do
@@ -239,8 +239,8 @@ RSpec.describe OsPlacesApi::Client do
 
         expect(client.locations_for_postcode(postcode).as_json).to eq(
           {
-            "average_latitude" => locations[0].latitude,
-            "average_longitude" => locations[0].longitude,
+            "average_latitude" => 51.514466600000006,
+            "average_longitude" => -0.07298125,
             "results" => [locations[0]].as_json,
           },
         )
@@ -327,11 +327,6 @@ RSpec.describe OsPlacesApi::Client do
           },
         }
         stub_request(:get, api_endpoint).to_return(status: 200, body: os_places_api_result_without_location.to_json)
-        expect { client.locations_for_postcode(postcode) }.to raise_error(OsPlacesApi::NoResultsForPostcode)
-      end
-
-      it "raises an exception if the postcode is in OS Places API datasets but all locations are filtered out" do
-        stub_request(:get, api_endpoint).to_return(status: 200, body: filterable_response.to_json)
         expect { client.locations_for_postcode(postcode) }.to raise_error(OsPlacesApi::NoResultsForPostcode)
       end
 


### PR DESCRIPTION
Sometimes we get a result set (example: TR21 0LW) where all the results  are filtered out as not suitable for displaying, but which still give us  a lat/lon suitable for geocoding. This change calculates lat/lon before  filtering, so we can now return results for this situation (av lat/lon  with no individual results) rather than an error.

We remove the test that an error gets raised if we have no results after  filtering, because this is now a valid thing to return.

https://trello.com/c/rAL7Q3JC/1668-investigate-and-fix-missing-postcodes-in-locations-api

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
