### PR TITLE
Prevent street records appearing in results but keep in averages.

### DIFF
--- a/lib/os_places_api/client.rb
+++ b/lib/os_places_api/client.rb
@@ -60,7 +60,10 @@ module OsPlacesApi
     end
 
     def filtered_locations(results)
-      filtered_hash = results_hash_with_uniq_uprns(results).reject { |r| NATIONAL_AUTHORITIES.include? r["LOCAL_CUSTODIAN_CODE_DESCRIPTION"] }
+      filtered_hash = results_hash_with_uniq_uprns(results).reject do |r|
+        (NATIONAL_AUTHORITIES.include? r["LOCAL_CUSTODIAN_CODE_DESCRIPTION"]) ||
+          (r["POSTAL_ADDRESS_CODE"] == "N")
+      end
       hash_to_locations(filtered_hash)
     end
 

--- a/spec/lib/os_places_api/client_spec.rb
+++ b/spec/lib/os_places_api/client_spec.rb
@@ -246,6 +246,20 @@ RSpec.describe OsPlacesApi::Client do
         )
       end
 
+      it "should include records with POSTAL_ADDRESS_CODE='N' in averages, but filter them from results" do
+        os_places_api_results[1]["LPI"]["POSTAL_ADDRESS_CODE"] = "N"
+        stub_request(:get, api_endpoint)
+          .to_return(status: 200, body: successful_response.to_json)
+
+        expect(client.locations_for_postcode(postcode).as_json).to eq(
+          {
+            "average_latitude" => average_latitude,
+            "average_longitude" => average_longitude,
+            "results" => [locations[0]].as_json,
+          },
+        )
+      end
+
       it "should cache the response from a successful request" do
         stub_request(:get, api_endpoint)
           .to_return(status: 200, body: successful_response.to_json)


### PR DESCRIPTION
Now we're doing split postcode choosing in frontend, we're seeing street  records (eg for WV14 8TU: "STREET RECORD, BRIERLEY LANE, WOLVERHAMPTON,  WV14 8TU") appearing in the drop-down lists of addresses people choose  from to disambiguate. Since they're valid records we should allow them  for the purposes of creating an average lng/lat for a postcode, but  filter them out from address results returned through the API.

Trello:
https://trello.com/c/HjgjrOCq/1580-support-split-postcodes-in-frontend

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
