### PR TITLE
Unpin ruby from patch versions in gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
+ruby "~> 3.1.0"
 gem "rails", "7.0.4"
 
 gem "bootsnap"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -451,5 +451,8 @@ DEPENDENCIES
   simplecov
   webmock
 
+RUBY VERSION
+   ruby 3.1.2p20
+
 BUNDLED WITH
    2.3.24


### PR DESCRIPTION
https://gds.slack.com/archives/CD6JUFXML/p1670600201164689

Unpin ruby patch level so that it will accept higher patch levels when deployed/tested.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
