### PR TITLE
Hold back bad version 2.8.0 of the `mail` rubygem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem "gds-api-adapters"
 gem "govuk_app_config"
 gem "govuk_sidekiq"
 gem "httparty"
+gem "mail", "~> 2.7.1"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "pact", require: false
 gem "pact_broker-client"
 gem "pg"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -439,6 +439,7 @@ DEPENDENCIES
   govuk_test
   httparty
   listen
+  mail (~> 2.7.1)
   pact
   pact_broker-client
   pg


### PR DESCRIPTION
Version 2.8.0 of the `mail` gem has the wrong filesystem permissions on a few of its .rb files (seems to be the generated tables?), which breaks the app when running as an unprivileged user. We therefore need to hold back this version of the gem until a new version is released that fixes the issue.

The upstream bug is mikel/mail#1489. We can remove this workaround once the bug is fixed.
