### PR TITLE
Fix sidekiq default logger setting.

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,9 +1,6 @@
 require "sidekiq-unique-jobs"
 
 Sidekiq.configure_server do |config|
-  # Calls to Rails.logger in a sidekiq process will use Sidekiq's logger
-  Rails.logger = Sidekiq::Logging.logger
-
   config.client_middleware do |chain|
     chain.add SidekiqUniqueJobs::Middleware::Client
   end


### PR DESCRIPTION
Fixes locations-api sidekiq not being able to start because of an outdated snippet that tries to redirect sidekiq logging to rails logger (which is the default now)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
