### PR TITLE
Remove workaround for bad `mail` gem release.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ gem "gds-api-adapters"
 gem "govuk_app_config"
 gem "govuk_sidekiq"
 gem "httparty"
-gem "mail", "~> 2.7.1"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "pact", require: false
 gem "pact_broker-client"
 gem "pg"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,9 +94,9 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
+    date (3.3.3)
     diff-lcs (1.5.0)
     dig_rb (1.0.1)
-    digest (3.1.0)
     docile (1.4.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
@@ -166,8 +166,11 @@ GEM
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.7.1)
+    mail (2.8.0.1)
       mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
@@ -179,20 +182,15 @@ GEM
     minitest (5.17.0)
     msgpack (1.6.0)
     multi_xml (0.6.0)
-    net-imap (0.2.3)
-      digest
+    net-imap (0.3.4)
+      date
       net-protocol
-      strscan
-    net-pop (0.1.1)
-      digest
+    net-pop (0.1.2)
       net-protocol
+    net-protocol (0.2.1)
       timeout
-    net-protocol (0.1.3)
-      timeout
-    net-smtp (0.3.1)
-      digest
+    net-smtp (0.3.3)
       net-protocol
-      timeout
     netrc (0.11.0)
     nio4r (2.5.8)
     nokogiri (1.13.10)
@@ -385,14 +383,13 @@ GEM
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     statsd-ruby (1.5.0)
-    strscan (3.0.4)
     sync (0.5.0)
     table_print (1.5.7)
     term-ansicolor (1.7.1)
       tins (~> 1.0)
     thor (1.2.1)
     tilt (2.0.11)
-    timeout (0.3.0)
+    timeout (0.3.1)
     tins (1.32.1)
       sync
     tzinfo (2.0.5)
@@ -433,7 +430,6 @@ DEPENDENCIES
   govuk_test
   httparty
   listen
-  mail (~> 2.7.1)
   pact
   pact_broker-client
   pg


### PR DESCRIPTION
Remove the version constraint that we were using to avoid the bad release of the `mail` gem, now that https://www.github.com/mikel/mail/issues/1489 is fixed.

Update to `2.8.0.1`, which fixes the permissions issue.

Generated with `gsed -i '/gem "mail"/d' && bundle update mail`.
