### PR TITLE
Fix bug where nil results returned by OS Places API weren't handled in worker

### DIFF
--- a/app/models/postcode_manager.rb
+++ b/app/models/postcode_manager.rb
@@ -12,14 +12,15 @@ class PostcodeManager
     normalised_postcode = PostcodeHelper.normalise(postcode)
     record = Postcode.os_places.find_by(postcode: normalised_postcode)
     location_results = location_results_from_os_places_api(normalised_postcode)
+    raise OsPlacesApi::NoResultsForPostcode if location_results.empty?
 
-    if location_results.empty?
-      record.destroy if record
-    elsif record
+    if record
       record.update(results: location_results.results) && record.touch
     else
       Postcode.create!(postcode: normalised_postcode, source: "os_places", results: location_results.results)
     end
+  rescue OsPlacesApi::NoResultsForPostcode
+    record.destroy if record
   end
 
 private

--- a/spec/models/postcode_manager_spec.rb
+++ b/spec/models/postcode_manager_spec.rb
@@ -106,7 +106,19 @@ RSpec.describe PostcodeManager, type: :model do
         Postcode.create!(postcode: normalised_postcode)
       end
 
-      context "the api returns no locations" do
+      context "the api returns no results" do
+        before do
+          mock_os_client_no_results
+        end
+
+        it "deletes the postcode record" do
+          expect(Postcode.where(postcode: normalised_postcode).count).to eq(1)
+          postcode_manager.update_postcode(postcode)
+          expect(Postcode.where(postcode: normalised_postcode).count).to eq(0)
+        end
+      end
+
+      context "the api returns no valid locations" do
         before do
           mock_os_client_empty_results
         end

--- a/spec/support/os_client_helper.rb
+++ b/spec/support/os_client_helper.rb
@@ -1,3 +1,10 @@
+def mock_os_client_no_results
+  os_client = double("os_client")
+  allow(OsPlacesApi::Client).to receive(:new).and_return(os_client)
+  allow(os_client).to receive(:retrieve_locations_for_postcode).and_raise(OsPlacesApi::NoResultsForPostcode)
+  os_client
+end
+
 def mock_os_client_empty_results
   os_client = double("os_client")
   allow(OsPlacesApi::Client).to receive(:new).and_return(os_client)


### PR DESCRIPTION
The refactoring of OS Places client when the ONSPD importer was added missed the situation where a postcode returns nil results (as opposed to returning empty results, or more commonly results which are empty after being filtered for valid addresses). The client now raises a NoResultsForPostcode error if the results are nil, so we use that as a marker for when a record should be deleted. Tests added for this situation.

https://trello.com/c/G2qTb0DC/2233-investigate-locations-api-error

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
