### PR TITLE
Freshness metrics

### DIFF
--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -1,2 +1,4 @@
 require "govuk_app_config/govuk_prometheus_exporter"
-GovukPrometheusExporter.configure
+require "collectors/global_prometheus_collector"
+
+GovukPrometheusExporter.configure(collectors: [Collectors::GlobalPrometheusCollector])

--- a/lib/collectors/global_prometheus_collector.rb
+++ b/lib/collectors/global_prometheus_collector.rb
@@ -1,0 +1,28 @@
+require "prometheus_exporter"
+require "prometheus_exporter/server"
+
+module Collectors
+  class GlobalPrometheusCollector < PrometheusExporter::Server::TypeCollector
+    SECONDS_PER_DAY = 86_400
+
+    def type
+      "locations_api_global"
+    end
+
+    def metrics
+      oldest_os_places_postcode = PrometheusExporter::Metric::Gauge.new("locations_api_oldest_os_places_postcode_age_days", "Days since oldest postcode was last updated via OS Places API (Expected in prod: ~7)")
+      oldest_os_places_postcode.observe(get_oldest_postcode / SECONDS_PER_DAY)
+
+      [oldest_os_places_postcode]
+    end
+
+  private
+
+    def get_oldest_postcode
+      # Cache metric to prevent needless expensive calls to the database
+      Rails.cache.fetch("metrics:oldest_postcode", expires_in: 1.hour) do
+        (Time.zone.now.to_i - Postcode.os_places.order(updated_at: :asc).first.updated_at.to_i)
+      end
+    end
+  end
+end

--- a/spec/lib/collectors/global_prometheus_collector_spec.rb
+++ b/spec/lib/collectors/global_prometheus_collector_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+
+RSpec.describe Collectors::GlobalPrometheusCollector do
+  before do
+    @collector = Collectors::GlobalPrometheusCollector.new
+    Rails.cache.delete("metrics:oldest_postcode")
+  end
+
+  describe "#type" do
+    it "has the correct value" do
+      expect(@collector.type).to eq("locations_api_global")
+    end
+  end
+
+  describe "#metrics" do
+    before do
+      @postcode = Postcode.create!(postcode: "E18QS", updated_at: Time.zone.now - 2.days)
+    end
+
+    it "records the time in days since the oldest postcode's update timestamp" do
+      metrics = @collector.metrics
+
+      expect(metrics.first.data.first.last).to eq(2)
+    end
+  end
+end

--- a/spec/service_consumer/pact_helper.rb
+++ b/spec/service_consumer/pact_helper.rb
@@ -36,6 +36,9 @@ Pact.provider_states_for "GDS API Adapters" do
   set_up do
     ENV["OS_PLACES_API_KEY"] = "some_key"
     ENV["OS_PLACES_API_SECRET"] = "some_secret"
+  end
+
+  tear_down do
     postcode = Postcode.find_by(postcode: "SW1A1AA")
     postcode.destroy unless postcode.nil?
   end


### PR DESCRIPTION
Adds a freshness metric for OS Places postcodes. Every hour we update the oldest postcode sourced from OS Places APi and allow prometheus to collect its age rounded down to the day. We can then see a graph of the age in seconds of the least-recently updated postcode. Since we're expecting the entire database to be refreshed roughly once a week, we should see this hover around the 7 mark. If it increases significantly above that, we may be seeing problems.

We will evaluate this for a while before deciding if we need to add an alarm state to it.

https://trello.com/c/8P4LRqvl/2171-investigate-how-we-can-handle-os-places-api-being-down

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
