### PR TITLE
Downgrade psych to 4.0.6 to allow building

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem "httparty"
 gem "pact", require: false
 gem "pact_broker-client"
 gem "pg"
+gem "psych", "<5"
 gem "rubyzip"
 gem "sentry-sidekiq"
 gem "sidekiq-scheduler"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -476,7 +476,7 @@ GEM
     plek (5.0.0)
     prometheus_exporter (2.0.8)
       webrick
-    psych (5.1.0)
+    psych (4.0.6)
       stringio
     public_suffix (5.0.3)
     puma (6.4.0)
@@ -684,6 +684,7 @@ DEPENDENCIES
   pact
   pact_broker-client
   pg
+  psych (< 5)
   rails (= 7.1.0)
   rspec-rails
   rubocop-govuk


### PR DESCRIPTION
Temporary fix for the problem of Psych being required by irb, but Psych 5+ not building against our images.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
