### PR TITLE
Remove brackets, array handling

### DIFF
--- a/lib/sidekiq_scheduler_backoff_service.rb
+++ b/lib/sidekiq_scheduler_backoff_service.rb
@@ -23,11 +23,11 @@ private
 
   def current_interval
     schedule = Sidekiq.get_schedule[name]
-    Integer(schedule["every"].first.chop)
+    Integer(schedule["every"].chop)
   end
 
   def restart_schedule(target_interval)
     schedule = Sidekiq.get_schedule[name]
-    Sidekiq.set_schedule(name, schedule.merge("every" => ["#{target_interval}s"]))
+    Sidekiq.set_schedule(name, schedule.merge("every" => "#{target_interval}s"))
   end
 end

--- a/spec/lib/sidekiq_scheduler_backoff_service_spec.rb
+++ b/spec/lib/sidekiq_scheduler_backoff_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe SidekiqSchedulerBackoffService do
 
       it "sets the scheduler to maximum speed and reloads the schedule" do
         subject.record_failure
-        expect(scheduled_interval).to eq(["#{min_interval}s"])
+        expect(scheduled_interval).to eq("#{min_interval}s")
       end
     end
 
@@ -25,7 +25,7 @@ RSpec.describe SidekiqSchedulerBackoffService do
 
       it "halves the scheduler speed and reloads the schedule" do
         subject.record_failure
-        expect(scheduled_interval).to eq(["#{max_interval}s"])
+        expect(scheduled_interval).to eq("#{max_interval}s")
       end
     end
 
@@ -36,7 +36,7 @@ RSpec.describe SidekiqSchedulerBackoffService do
 
       it "does nothing" do
         subject.record_failure
-        expect(scheduled_interval).to eq(["#{max_interval}s"])
+        expect(scheduled_interval).to eq("#{max_interval}s")
       end
     end
 
@@ -47,7 +47,7 @@ RSpec.describe SidekiqSchedulerBackoffService do
 
       it "sets the scheduler to minimum speed and reloads the schedule" do
         subject.record_failure
-        expect(scheduled_interval).to eq(["#{max_interval}s"])
+        expect(scheduled_interval).to eq("#{max_interval}s")
       end
     end
   end
@@ -60,7 +60,7 @@ RSpec.describe SidekiqSchedulerBackoffService do
 
       it "sets the scheduler to maximum speed and reloads the schedule" do
         subject.record_success
-        expect(scheduled_interval).to eq(["#{min_interval}s"])
+        expect(scheduled_interval).to eq("#{min_interval}s")
       end
     end
 
@@ -71,7 +71,7 @@ RSpec.describe SidekiqSchedulerBackoffService do
 
       it "does nothing" do
         subject.record_success
-        expect(scheduled_interval).to eq(["#{min_interval}s"])
+        expect(scheduled_interval).to eq("#{min_interval}s")
       end
     end
 
@@ -82,7 +82,7 @@ RSpec.describe SidekiqSchedulerBackoffService do
 
       it "decremenincrements the scheduler speed by 1 second and reloads the schedule" do
         subject.record_success
-        expect(scheduled_interval).to eq(["#{(min_interval * 4) - 1}s"])
+        expect(scheduled_interval).to eq("#{(min_interval * 4) - 1}s")
       end
     end
 
@@ -93,14 +93,14 @@ RSpec.describe SidekiqSchedulerBackoffService do
 
       it "sets the scheduler to minimum speed and reloads the schedule" do
         subject.record_success
-        expect(scheduled_interval).to eq(["#{max_interval}s"])
+        expect(scheduled_interval).to eq("#{max_interval}s")
       end
     end
   end
 end
 
 def set_scheduled_interval(interval)
-  Sidekiq.set_schedule(name.to_s, { "every" => ["#{interval}s"], "class" => "PostcodesCollectionWorker" })
+  Sidekiq.set_schedule(name.to_s, { "every" => "#{interval}s", "class" => "PostcodesCollectionWorker" })
 end
 
 def scheduled_interval


### PR DESCRIPTION
For some reason, it appeared that the value of "every" keys in sidekiq scheduler were arrays. This is not the case, and also for some reason this doesn't cause problems in any environment apart from production.

(eg: in reality the structure is { "every" -> "1s" }, but in development it appeared to be { "every" -> ["1s"] }

Fix to resolve:
https://govuk.sentry.io/issues/4543279413/?project=6288896&query=&referrer=project-issue-stream

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
