### PR TITLE
Heed RAILS_LOG_LEVEL.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -41,6 +41,8 @@ Rails.application.configure do
     .tap  { |logger| logger.formatter = ::Logger::Formatter.new }
     .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
 
+  config.log_level = ENV.fetch("RAILS_LOG_LEVEL", :info)
+
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -10,6 +10,8 @@ Sidekiq.configure_server do |config|
     chain.add SidekiqUniqueJobs::Middleware::Server
   end
 
+  config.logger.level = Rails.logger.level
+
   SidekiqUniqueJobs::Server.configure(config)
 end
 


### PR DESCRIPTION
For https://github.com/alphagov/govuk-helm-charts/pull/1714.

I believe this is still the way we're supposed to do it. Let me know if not :)

https://guides.rubyonrails.org/debugging_rails_applications.html#log-levels
https://github.com/sidekiq/sidekiq/wiki/Logging#default-logger-and-verboseness