### PR TITLE
Automatic ONSPD Updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem "pact", require: false
 gem "pact_broker-client"
 gem "pg"
 gem "psych", "<6"
+gem "rss"
 gem "rubyzip"
 gem "sentry-sidekiq"
 gem "sidekiq-scheduler"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -571,6 +571,8 @@ GEM
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
     rspec-support (3.13.1)
+    rss (0.3.0)
+      rexml
     rubocop (1.62.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -694,6 +696,7 @@ DEPENDENCIES
   psych (< 6)
   rails (= 7.1.3.2)
   rspec-rails
+  rss
   rubocop-govuk
   rubyzip
   sentry-sidekiq

--- a/app/workers/ons_update_check_worker.rb
+++ b/app/workers/ons_update_check_worker.rb
@@ -1,0 +1,36 @@
+require "rss"
+require "open-uri"
+
+class OnsUpdateCheckWorker < OnsBaseWorker
+  ONSPD_RSS_URL = "https://geoportal.statistics.gov.uk/api/feed/rss/2.0?q=PRD_ONSPD&sort=Date%20Created%7Ccreated%7Cdesc".freeze
+
+  def perform
+    URI.parse(ONSPD_RSS_URL).open do |rss|
+      feed = RSS::Parser.parse(rss)
+
+      newest = feed.items.first
+
+      if more_recent?(newest)
+        new_data_url = "https://www.arcgis.com/sharing/rest/content/items/#{arcgis_item_id(newest)}/data"
+        Rails.logger.info("Updated ONSPD file: #{newest.title}")
+        Rails.logger.info("Starting download from #{new_data_url}")
+        OnsDownloadWorker.perform_async(new_data_url)
+      end
+    end
+  end
+
+private
+
+  def more_recent?(item)
+    return true unless Postcode.onspd.any?
+
+    item.pubDate > Postcode.onspd.maximum(:updated_at)
+  end
+
+  def arcgis_item_id(item)
+    matches = item.guid.content.match(/id=(\h+)/)
+    raise StandardError("OnsUpdateCheckWorker couldn't extract download item from [#{item.guid.content}]") unless matches
+
+    matches[1]
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -11,3 +11,6 @@
     queue_oldest_postcodes_for_updating:
       every: '1s'
       class: PostcodesCollectionWorker
+    queue_ons_check_updates:
+      every: '1d'
+      class: OnsUpdateCheckWorker

--- a/docs/updating-ons-postcode-data.md
+++ b/docs/updating-ons-postcode-data.md
@@ -2,11 +2,13 @@
 
 High-quality postcode data using in Locations API comes from the Ordnance Survey. But that dataset does not include all postcodes active (for instance, it excludes large user postcodes), nor does it include historical postcodes that people may still be using. To support this, we can import lower-quality postcode information from the Office for National Statistics Postcode Directory. The system will always use the high quality data where possible, but can use the low-quality data for geolocating in imminence datasets and lookups.
 
-The Postcode Directory is updated a couple of times a year. Every few months, someone should check to see if there is a new version of the data and update it.
+The Postcode Directory is updated a couple of times a year. An OnsUpdateCheckWorker checks the ONS rss feed once a day to see if a new version of the postcode data has been published, and if so starts an OnsDownloadWorker. This downloads the relevant file, splits out the multi-csv directory into an S3 bucket, and starts a single OnsImportWorker for each of the files.
+
+## Manual Updates
+
+In the event that a manual update is necessary, you can start an OnsDownloadWorker like this.
 
 - Visit https://geoportal.statistics.gov.uk/search?collection=Dataset&sort=-created&tags=all(PRD_ONSPD) to see if there is a new version.
 - Visit the page for the new version. There should be a Download link on the page. Copy the URL from that link.
 - On the locations-api shell, run the rake task: `rails import_ons_data[<url you copied earlier>]`
-
-This rake task will start an OnsDownloadWorker, which downloads the file, splits out the multi-csv directory into an S3 bucket, and starts a single OnsImportWorker for each of the files.
 

--- a/spec/support/rss_helper.rb
+++ b/spec/support/rss_helper.rb
@@ -1,0 +1,28 @@
+require "rss"
+
+def ons_rss(last_updated: Time.zone.now)
+  ons_base_rss(last_updated:, guid: "https://www.arcgis.com/home/item.html?id=abc123")
+end
+
+def broken_ons_rss(last_updated: Time.zone.now)
+  ons_base_rss(last_updated:, guid: "https://www.arcgis.com/home/item.html")
+end
+
+def ons_base_rss(last_updated:, guid:)
+  rss = RSS::Maker.make("2.0") do |maker|
+    maker.channel.description = "ONSPD Search"
+    maker.channel.updated = last_updated.to_s
+    maker.channel.title = "Open Geography Portal"
+    maker.channel.link = "https://geoportal.statistics.gov.uk/"
+
+    maker.items.new_item do |item|
+      item.link = "https://geoportal.statistics.gov.uk/datasets/ons::ons-postcode-directory-february-2024"
+      item.title = "ONS Postcode Directory (#{last_updated.strftime('%B %Y')})"
+      item.updated = last_updated.to_s
+      guid_obj = RSS::Rss::Channel::Item::Guid.new(true, guid)
+      guid_obj.setup_maker(item)
+    end
+  end
+
+  rss.to_s
+end

--- a/spec/workers/ons_update_check_worker_spec.rb
+++ b/spec/workers/ons_update_check_worker_spec.rb
@@ -1,0 +1,56 @@
+require "spec_helper"
+
+UPDATE_RSS = "".freeze
+NO_UPDATE_RSS = "".freeze
+
+RSpec.describe OnsUpdateCheckWorker do
+  describe "#perform" do
+    context "with no applicable update in the RSS feed" do
+      before do
+        stub_request(:get, "https://geoportal.statistics.gov.uk/api/feed/rss/2.0?q=PRD_ONSPD&sort=Date%20Created%7Ccreated%7Cdesc").to_return(body: ons_rss(last_updated: Time.zone.now - 1.month))
+      end
+
+      context "with no existing onspd records" do
+        it "starts an OnsDownloadWorker" do
+          expect(OnsDownloadWorker).to receive(:perform_async).with("https://www.arcgis.com/sharing/rest/content/items/abc123/data")
+          OnsUpdateCheckWorker.new.perform
+        end
+      end
+
+      context "with existing onspd records" do
+        before do
+          Postcode.create!(postcode: "AB10AA", source: "onspd", created_at: Time.zone.now - 1.day, updated_at: Time.zone.now - 1.day)
+        end
+
+        it "does nothing" do
+          expect(OnsDownloadWorker).not_to receive(:perform_async)
+          OnsUpdateCheckWorker.new.perform
+        end
+      end
+    end
+
+    context "with a new update in the RSS feed" do
+      before do
+        Postcode.create!(postcode: "AB10AA", source: "onspd", created_at: Time.zone.now - 1.day, updated_at: Time.zone.now - 1.day)
+        stub_request(:get, "https://geoportal.statistics.gov.uk/api/feed/rss/2.0?q=PRD_ONSPD&sort=Date%20Created%7Ccreated%7Cdesc").to_return(body: ons_rss)
+      end
+
+      it "starts an OnsDownloadWorker" do
+        expect(OnsDownloadWorker).to receive(:perform_async).with("https://www.arcgis.com/sharing/rest/content/items/abc123/data")
+        OnsUpdateCheckWorker.new.perform
+      end
+    end
+
+    context "with a new update in the RSS feed but the item is broken" do
+      before do
+        Postcode.create!(postcode: "AB10AA", source: "onspd", created_at: Time.zone.now - 1.day, updated_at: Time.zone.now - 1.day)
+        stub_request(:get, "https://geoportal.statistics.gov.uk/api/feed/rss/2.0?q=PRD_ONSPD&sort=Date%20Created%7Ccreated%7Cdesc").to_return(body: broken_ons_rss)
+      end
+
+      it "raises an error and does not start an OnsDownloadWorker" do
+        expect(OnsDownloadWorker).not_to receive(:perform_async).with("https://www.arcgis.com/sharing/rest/content/items/abc123/data")
+        expect { OnsUpdateCheckWorker.new.perform }.to raise_error(StandardError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add a scheduled worker that will check for new versions of the ONS postcode data file appearing in their RSS feed, work out the download link, and then kick off the existing OnsDownloadWorker to update the ONS postcode data.

https://trello.com/c/MkrbhOh6/2409-investigate-automatically-detecting-onspd-data-updates-rss-feed

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
