### PR TITLE
Remove manual call to GovukError.notify

### DIFF
--- a/app/workers/process_postcode_worker.rb
+++ b/app/workers/process_postcode_worker.rb
@@ -5,8 +5,7 @@ class ProcessPostcodeWorker
   def perform(postcode)
     PostcodeManager.new.update_postcode(postcode)
     Rails.application.config.sidekiq_scheduler_backoff_service.record_success
-  rescue OsPlacesApi::ClientError => e
-    GovukError.notify(e)
+  rescue OsPlacesApi::ClientError
     Rails.application.config.sidekiq_scheduler_backoff_service.record_failure
   end
 end

--- a/spec/workers/process_postcode_worker_spec.rb
+++ b/spec/workers/process_postcode_worker_spec.rb
@@ -6,17 +6,26 @@ RSpec.describe ProcessPostcodeWorker do
 
     it "updates the given postcode" do
       stubbed_client = double("PostcodeManager")
-
-      expect(PostcodeManager).to receive(:new) { stubbed_client }
       expect(stubbed_client).to receive(:update_postcode).with(postcode)
+      expect(PostcodeManager).to receive(:new) { stubbed_client }
 
       ProcessPostcodeWorker.new.perform(postcode)
     end
 
-    it "notifies Sentry when an OS Places API Client exception is raised" do
+    it "records a success in the backoff service" do
+      stubbed_client = double("PostcodeManager")
+      expect(stubbed_client).to receive(:update_postcode).with(postcode)
+      expect(PostcodeManager).to receive(:new) { stubbed_client }
+
+      expect(Rails.application.config.sidekiq_scheduler_backoff_service).to receive(:record_success)
+
+      ProcessPostcodeWorker.new.perform(postcode)
+    end
+
+    it "records a failure in the backoff service when an OS Places API Client exception is raised" do
       allow(OsPlacesApi::Client).to receive(:new).and_raise(OsPlacesApi::RateLimitExceeded.new)
 
-      expect(GovukError).to receive(:notify).with(OsPlacesApi::RateLimitExceeded)
+      expect(Rails.application.config.sidekiq_scheduler_backoff_service).to receive(:record_failure)
 
       ProcessPostcodeWorker.new.perform(postcode)
     end


### PR DESCRIPTION
- Remove call
- Update tests for backoff service (to test properly, and maintain coverage

In https://github.com/alphagov/locations-api/pull/74, we added a manual call to GovukError.notify when an
exception was raised in Sidekiq. This was because Sentry would not receive any errors from Sidekiq.

However, govuk_app_config does support Sidekiq Sentry error reporting - it just needs the sentry-sidekiq gem adding. 

There was a PR about this (https://github.com/alphagov/locations-api/pull/81), which was never merged, but it seems that sentry-sidekiq has been added since anyway, so now we can remove the explicit call. That call was also providing coverage for an unrelated feature (recording success/failure for the backoff service), so improve the tests to cover that feature properly.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
