### PR TITLE
Additional logging and handling for missing schedule errors

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_05_101124) do
+ActiveRecord::Schema[7.1].define(version: 2023_06_05_101124) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/spec/lib/sidekiq_scheduler_backoff_service_spec.rb
+++ b/spec/lib/sidekiq_scheduler_backoff_service_spec.rb
@@ -50,6 +50,15 @@ RSpec.describe SidekiqSchedulerBackoffService do
         expect(scheduled_interval).to eq("#{max_interval}s")
       end
     end
+
+    context "when the schedule is missing" do
+      subject { SidekiqSchedulerBackoffService.new(name: "non-existing-queue", min_interval:, max_interval:) }
+
+      it "records the problem to GovukError" do
+        expect(GovukError).to receive(:notify)
+        subject.record_failure
+      end
+    end
   end
 
   describe "#record_success" do
@@ -94,6 +103,15 @@ RSpec.describe SidekiqSchedulerBackoffService do
       it "sets the scheduler to minimum speed and reloads the schedule" do
         subject.record_success
         expect(scheduled_interval).to eq("#{max_interval}s")
+      end
+    end
+
+    context "when the schedule is missing" do
+      subject { SidekiqSchedulerBackoffService.new(name: "non-existing-queue", min_interval:, max_interval:) }
+
+      it "records the problem to GovukError" do
+        expect(GovukError).to receive(:notify)
+        subject.record_success
       end
     end
   end


### PR DESCRIPTION
- Hard to track error in integration where the ProcessPostcodeWorker can't affect the backoff service because it can't see the scheduler. Can't replicate on the console, so add a bit of logging and defaults so that Sentry isn't overwhelmed with this odd error.

Example:
https://govuk.sentry.io/issues/5348616796/?environment=integration&project=6288896&referrer=project-issue-stream

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

⚠️ Coverage note: test suite is set to fail if coverage drops below 100%. If you need to merge in an emergency, you will have to temporarily change branch protection rules. ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
