### PR TITLE
Use GOVUK_ENVIRONMENT instead of GOVUK_ENVIRONMENT_NAME

### DIFF
--- a/app/workers/ons_base_worker.rb
+++ b/app/workers/ons_base_worker.rb
@@ -4,7 +4,7 @@ class OnsBaseWorker
   include Sidekiq::Worker
   sidekiq_options queue: :queue_ons, lock: :until_executed, lock_timeout: nil
 
-  BUCKET_NAME = "govuk-#{ENV['GOVUK_ENVIRONMENT_NAME']}-locations-api-import-csvs".freeze
+  BUCKET_NAME = "govuk-#{ENV['GOVUK_ENVIRONMENT']}-locations-api-import-csvs".freeze
 
   def s3_client
     @s3_client ||= Aws::S3::Client.new(region: "eu-west-1")


### PR DESCRIPTION
Both environment variables are set to the same value. GOVUK_ENVIRONMENT is used more frequently, renaming for consistency.