### PR TITLE
Index update, Phase 2: Use new large_user_postcode index

### DIFF
--- a/app/models/postcode.rb
+++ b/app/models/postcode.rb
@@ -7,6 +7,9 @@ class Postcode < ApplicationRecord
   scope :active, -> { where(retired: false) }
   scope :retired, -> { where(retired: true) }
 
+  scope :small, -> { where(large_user_postcode: false) }
+  scope :large, -> { where(large_user_postcode: true) }
+
 private
 
   def normalize_postcode

--- a/app/workers/postcodes_collection_worker.rb
+++ b/app/workers/postcodes_collection_worker.rb
@@ -12,9 +12,7 @@ private
 
   def postcodes
     Postcode.uncached do
-      onspd_candidates = Postcode.onspd.active.order("updated_at ASC").select { |r| r.results.first["ONS"]["TYPE"] == "S" }.first(POSTCODES_PER_SECOND)
-      os_places_candidates = Postcode.os_places.order("updated_at ASC").first(POSTCODES_PER_SECOND)
-      (onspd_candidates + os_places_candidates).sort_by(&:updated_at).first(POSTCODES_PER_SECOND).pluck(:postcode)
+      Postcode.active.small.order("updated_at ASC").limit(POSTCODES_PER_SECOND).pluck(:postcode)
     end
   end
 end

--- a/spec/workers/postcodes_collection_worker_spec.rb
+++ b/spec/workers/postcodes_collection_worker_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe PostcodesCollectionWorker do
 
     context "when an ONSPD small active postcode is older than the oldest OS Places postcode" do
       before do
-        Postcode.create(postcode: "E12AA", source: "onspd", updated_at: 3.days.ago, results: [{ "ONS" => { "TYPE" => "S" } }])
+        Postcode.create(postcode: "E12AA", source: "onspd", updated_at: 3.days.ago)
       end
 
       it "adds the onspd postcode to the update checker" do
@@ -35,7 +35,7 @@ RSpec.describe PostcodesCollectionWorker do
 
     context "when an ONSPD small retired postcode is older than the oldest OS Places postcode" do
       before do
-        Postcode.create(postcode: "E12AA", source: "onspd", updated_at: 3.days.ago, results: [{ "ONS" => { "TYPE" => "S" } }], retired: true)
+        Postcode.create(postcode: "E12AA", source: "onspd", updated_at: 3.days.ago, retired: true)
       end
 
       it "does not attempt to update the ONSPD postcode" do
@@ -47,7 +47,7 @@ RSpec.describe PostcodesCollectionWorker do
 
     context "when an ONSPD large active postcode is older than the oldest OS Places postcode" do
       before do
-        Postcode.create(postcode: "E12AA", source: "onspd", updated_at: 3.days.ago, results: [{ "ONS" => { "TYPE" => "L" } }])
+        Postcode.create(postcode: "E12AA", source: "onspd", updated_at: 3.days.ago, large_user_postcode: true)
       end
 
       it "does not attempt to update the ONSPD postcode" do


### PR DESCRIPTION
The updates added in [PR #556](https://github.com/alphagov/locations-api/pull/556) included a naive method of identifying relevant ONSPD records to update (fetching a list which had to be filtered by a select statement), resulting in a notable bump in CPU usage by the worker threads. This PR moves the "size" element from the free-form JSON results field into a specific field which can be indexed and searched in a single search. 

Speed of the query code as reported by benchmark:

Before:
0.473827 s / call

After
0.000685 s / call

(Speed improvement of 690x on this code, which is called once a second)

Obviously there's a cost in writing, because the index has to be updated, so it's not plain sailing, but the benefits should outweigh the cost, we can monitor that on CPU usage.

Integration worker CPU and memory load over the last two weeks - low before PR 556, high after it, then low again after this PR is temporarily deployed - CPU and memory load seem to be marginally better even than before PR 556

![image](https://github.com/user-attachments/assets/d2fc9c24-fd53-4052-89df-e3d9ff3de22d)

Actual index and migration task added in https://github.com/alphagov/locations-api/pull/610

https://trello.com/c/Pf89f3wr/350-improve-worker-cpu-usage-on-locations-api

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

⚠️ Coverage note: test suite is set to fail if coverage drops below 100%. If you need to merge in an emergency, you will have to temporarily change branch protection rules. ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
