### PR TITLE
Index update, Phase 1: Add large_user_postcode flag and index

### DIFF
--- a/db/migrate/20250211143015_update_postcodes_add_lup_flag.rb
+++ b/db/migrate/20250211143015_update_postcodes_add_lup_flag.rb
@@ -1,0 +1,13 @@
+class UpdatePostcodesAddLupFlag < ActiveRecord::Migration[8.0]
+  def up
+    add_column :postcodes, :large_user_postcode, :boolean, default: false, null: false
+
+    add_index :postcodes, %i[retired large_user_postcode updated_at]
+  end
+
+  def down
+    remove_index :postcodes, %i[retired large_user_postcode updated_at]
+
+    remove_column :postcodes, :large_user_postcode, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_23_162617) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_11_143015) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -27,7 +27,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_23_162617) do
     t.datetime "updated_at", null: false
     t.string "source", default: "os_places", null: false
     t.boolean "retired", default: false, null: false
+    t.boolean "large_user_postcode", default: false, null: false
     t.index ["postcode"], name: "index_postcodes_on_postcode", unique: true
+    t.index ["retired", "large_user_postcode", "updated_at"], name: "idx_on_retired_large_user_postcode_updated_at_4195f25cc2"
     t.index ["retired"], name: "index_postcodes_on_retired"
     t.index ["source"], name: "index_postcodes_on_source"
   end

--- a/lib/tasks/update_lup_flag.rake
+++ b/lib/tasks/update_lup_flag.rake
@@ -1,0 +1,8 @@
+desc "Update all "
+task update_lup_flag: :environment do
+  Postcode.onspd.find_in_batches(batch_size: 50) do |group|
+    group.select { |r| r.results.first["ONS"]["TYPE"] == "L" }.each do |r|
+      r.update(large_user_postcode: true)
+    end
+  end
+end

--- a/spec/lib/tasks/update_lup_flag_spec.rb
+++ b/spec/lib/tasks/update_lup_flag_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+require "rake"
+
+RSpec.describe "update_lup_flag task" do
+  let(:task) { Rake::Task["update_lup_flag"] }
+
+  context "when the update_lup_flag task is invoked" do
+    before do
+      Postcode.create(postcode: "E12AA", source: "onspd", updated_at: 3.days.ago, results: [{ "ONS" => { "TYPE" => "L" } }])
+      Postcode.create(postcode: "E13AA", source: "onspd", updated_at: 3.days.ago, results: [{ "ONS" => { "TYPE" => "S" } }])
+    end
+
+    it "sets the large_user_postcode flag true for LUP postcodes, but not for small ones" do
+      task.reenable
+      task.invoke
+
+      expect(Postcode.onspd.where(postcode: "E12AA", large_user_postcode: true).count).to eq(1)
+      expect(Postcode.onspd.where(postcode: "E13AA", large_user_postcode: false).count).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
Related to: https://github.com/alphagov/locations-api/pull/572

...because the migration times out due to data fixup, releasing as 2 phases - this phase will add the index and fix up the data, the next phase will bring in the code once all data is fixed up correctly.

- relevant index used by postcode collection worker will be checking for active and small postcodes (ie retired and large_user_postcode = false), and ordered by updated_at.
- Default to large_user_postcode: false, set to true in a rake task from the existing ONSPD data. Only ONSPD records will ever be large_user_postcode: true, so we only need to check them, but they must be set before the code to use them is added, and since this will timeout a migration, we have to do it as a 2-phase deploy (1: migrate, update data, 2:  update code.)

https://trello.com/c/Pf89f3wr/350-improve-worker-cpu-usage-on-locations-api, [Jira issue PNP-6398](https://gov-uk.atlassian.net/browse/PNP-6398)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

⚠️ Coverage note: test suite is set to fail if coverage drops below 100%. If you need to merge in an emergency, you will have to temporarily change branch protection rules. ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
