### PR TITLE
Add dependabot cooldowns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,15 @@ updates:
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3
+      exclude:
+        - gds-api-adapters
+        - govuk_*
+        - rubocop-govuk
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
To add cooldown period for 
- bundler(3 days) with exclusion for alphagov gems that have their own cooldown
-  github-actions(3 days) 

Ref. https://docs.publishing.service.gov.uk/manual/manage-dependencies.html#example-configurations

[JIRA ticket](https://gov-uk.atlassian.net/browse/PNP-10048)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

⚠️ Coverage note: test suite is set to fail if coverage drops below 100%. If you need to merge in an emergency, you will have to temporarily change branch protection rules. ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
